### PR TITLE
Binary batch get

### DIFF
--- a/binprot/parser.go
+++ b/binprot/parser.go
@@ -189,7 +189,7 @@ func (b BinaryParser) Parse() (interface{}, common.RequestType, error) {
 			Keys:    [][]byte{key},
 			Opaques: []uint32{reqHeader.OpaqueToken},
 			Quiet:   []bool{false},
-			NoopEnd: false
+			NoopEnd: false,
 		}, common.REQUEST_GET, nil
 
 	case OPCODE_DELETE:

--- a/binprot/parser.go
+++ b/binprot/parser.go
@@ -231,10 +231,12 @@ func (b BinaryParser) Parse() (interface{}, common.RequestType, error) {
 func readBatchGet(r io.Reader, header RequestHeader) (common.GetRequest, error) {
 	keys := make([][]byte, 0)
 	opaques := make([]uint32, 0)
+	quiet := make([]bool, 0)
 
 	// while GETQ
 	// read key, read header
 	for header.Opcode == OPCODE_GETQ {
+		fmt.Println("GETQ")
 		// key
 		key, err := readString(r, header.KeyLength)
 
@@ -244,6 +246,7 @@ func readBatchGet(r io.Reader, header RequestHeader) (common.GetRequest, error) 
 
 		keys = append(keys, key)
 		opaques = append(opaques, header.OpaqueToken)
+		quiet = append(quiet, true)
 
 		// read in the next header
 		err = binary.Read(r, binary.BigEndian, &header)
@@ -254,6 +257,7 @@ func readBatchGet(r io.Reader, header RequestHeader) (common.GetRequest, error) 
 	}
 
 	if header.Opcode == OPCODE_GET {
+		fmt.Println("GET")
 		// key
 		key, err := readString(r, header.KeyLength)
 
@@ -263,7 +267,9 @@ func readBatchGet(r io.Reader, header RequestHeader) (common.GetRequest, error) 
 
 		keys = append(keys, key)
 		opaques = append(opaques, header.OpaqueToken)
+		quiet = append(quiet, false)
 	} else if header.Opcode == OPCODE_NOOP {
+		fmt.Println("NOOP")
 		// nothing to do, header is read already
 	} else {
 		// no idea... this is a problem though.

--- a/binprot/respond.go
+++ b/binprot/respond.go
@@ -133,8 +133,14 @@ func (b BinaryResponder) GetMiss(response common.GetResponse) error {
 	return nil
 }
 
-func (b BinaryResponder) GetEnd() error {
-	// no-op since the binary protocol does not have batch gets
+func (b BinaryResponder) GetEnd(noopEnd bool) error {
+	// if Noop was the end of the pipelined batch gets, respond with a Noop header
+	// otherwise, stay quiet as the last get would be a GET and not a GETQ
+	if noopEnd {
+		header := makeSuccessResponseHeader(OPCODE_NOOP, 0, 0, 0, 0)
+		return writeHeader(header, b.writer)
+	}
+
 	return nil
 }
 

--- a/binprot/respond.go
+++ b/binprot/respond.go
@@ -126,10 +126,11 @@ func (b BinaryResponder) Get(response common.GetResponse) error {
 }
 
 func (b BinaryResponder) GetMiss(response common.GetResponse) error {
-	if (!common.GetResponse.Quiet) {
+	if (!response.Quiet) {
 		header := makeErrorResponseHeader(OPCODE_GET, int(STATUS_KEY_ENOENT), 0)
 		return writeHeader(header, b.writer)
 	}
+	return nil
 }
 
 func (b BinaryResponder) GetEnd() error {

--- a/binprot/respond.go
+++ b/binprot/respond.go
@@ -126,8 +126,10 @@ func (b BinaryResponder) Get(response common.GetResponse) error {
 }
 
 func (b BinaryResponder) GetMiss(response common.GetResponse) error {
-	header := makeErrorResponseHeader(OPCODE_GET, int(STATUS_KEY_ENOENT), 0)
-	return writeHeader(header, b.writer)
+	if (!common.GetResponse.Quiet) {
+		header := makeErrorResponseHeader(OPCODE_GET, int(STATUS_KEY_ENOENT), 0)
+		return writeHeader(header, b.writer)
+	}
 }
 
 func (b BinaryResponder) GetEnd() error {

--- a/binprot/respond.go
+++ b/binprot/respond.go
@@ -126,7 +126,7 @@ func (b BinaryResponder) Get(response common.GetResponse) error {
 }
 
 func (b BinaryResponder) GetMiss(response common.GetResponse) error {
-	if (!response.Quiet) {
+	if !response.Quiet {
 		header := makeErrorResponseHeader(OPCODE_GET, int(STATUS_KEY_ENOENT), 0)
 		return writeHeader(header, b.writer)
 	}

--- a/client/binprot/headers.go
+++ b/client/binprot/headers.go
@@ -19,8 +19,6 @@ import "encoding/binary"
 import "errors"
 import "io"
 
-import "../common"
-
 const Get = 0x00
 const Set = 0x01
 const Add = 0x02
@@ -65,24 +63,7 @@ type req struct {
 	CAS      uint64
 }
 
-func opToCode(op common.Op) int {
-	switch op {
-	case common.GET:
-		return Get
-	case common.SET:
-		return Set
-	case common.TOUCH:
-		return Touch
-	case common.DELETE:
-		return Delete
-	default:
-		return -1
-	}
-}
-
-func writeReq(w io.Writer, op common.Op, keylen, extralen, bodylen int) error {
-	opcode := opToCode(op)
-
+func writeReq(w io.Writer, opcode int, keylen, extralen, bodylen int) error {
 	req := req{
 		Magic:    0x80,
 		Opcode:   uint8(opcode),

--- a/client/binprot/prot.go
+++ b/client/binprot/prot.go
@@ -51,7 +51,7 @@ func (b BinProt) Set(rw io.ReadWriter, key, value []byte) error {
 
 	// Header
 	bodylen := 8 + len(key) + len(value)
-	writeReq(rw, common.SET, len(key), 8, bodylen)
+	writeReq(rw, Set, len(key), 8, bodylen)
 	// Extras
 	binary.Write(rw, binary.BigEndian, uint32(0))
 	binary.Write(rw, binary.BigEndian, common.Exp())
@@ -65,7 +65,7 @@ func (b BinProt) Set(rw io.ReadWriter, key, value []byte) error {
 
 func (b BinProt) Get(rw io.ReadWriter, key []byte) error {
 	// Header
-	writeReq(rw, common.GET, len(key), 0, len(key))
+	writeReq(rw, Get, len(key), 0, len(key))
 	// Body
 	rw.Write(key)
 
@@ -73,9 +73,23 @@ func (b BinProt) Get(rw io.ReadWriter, key []byte) error {
 	return consumeResponse(rw)
 }
 
+func (b BinProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
+	for _, key := range keys {
+		// Header
+		writeReq(rw, GetQ, len(key), 0, len(key))
+		// Body
+		rw.Write(key)
+	}
+
+	writeReq(rw, Noop, 0, 0, 0)
+
+	// consume all of the response and discard
+	return consumeResponse(rw)
+}
+
 func (b BinProt) Delete(rw io.ReadWriter, key []byte) error {
 	// Header
-	writeReq(rw, common.DELETE, len(key), 0, len(key))
+	writeReq(rw, Delete, len(key), 0, len(key))
 	// Body
 	rw.Write(key)
 
@@ -85,7 +99,7 @@ func (b BinProt) Delete(rw io.ReadWriter, key []byte) error {
 
 func (b BinProt) Touch(rw io.ReadWriter, key []byte) error {
 	// Header
-	writeReq(rw, common.TOUCH, len(key), 4, len(key)+4)
+	writeReq(rw, Touch, len(key), 4, len(key)+4)
 	// Extras
 	binary.Write(rw, binary.BigEndian, common.Exp())
 	// Body

--- a/client/blast.go
+++ b/client/blast.go
@@ -49,13 +49,14 @@ func main() {
 	comms := new(sync.WaitGroup)
 
 	// TODO: Better math
-	opsPerTask := f.NumOps / 4 / f.NumWorkers
+	opsPerTask := f.NumOps / 5 / f.NumWorkers
 
 	// spawn task generators
 	for i := 0; i < f.NumWorkers; i++ {
-		taskGens.Add(4)
+		taskGens.Add(5)
 		go cmdGenerator(tasks, taskGens, opsPerTask, "set")
 		go cmdGenerator(tasks, taskGens, opsPerTask, "get")
+		go cmdGenerator(tasks, taskGens, opsPerTask, "bget")
 		go cmdGenerator(tasks, taskGens, opsPerTask, "delete")
 		go cmdGenerator(tasks, taskGens, opsPerTask, "touch")
 	}
@@ -120,6 +121,8 @@ func communicator(prot common.Prot, rw io.ReadWriter, tasks <-chan *common.Task,
 			err = prot.Set(rw, item.Key, item.Value)
 		case "get":
 			err = prot.Get(rw, item.Key)
+		case "bget":
+			err = prot.BatchGet(rw, batchkeys(item.Key))
 		case "delete":
 			err = prot.Delete(rw, item.Key)
 		case "touch":
@@ -140,4 +143,16 @@ func communicator(prot common.Prot, rw io.ReadWriter, tasks <-chan *common.Task,
 	fmt.Println("comm done")
 
 	comms.Done()
+}
+
+func batchkeys(key []byte) [][]byte {
+	key = key[1:]
+	retval := make([][]byte, 0)
+	numKeys := rand.Intn(25) + 2 + int('A')
+
+	for i := int('A'); i < numKeys; i++ {
+		retval = append(retval, append([]byte{byte(i)}, key...))
+	}
+
+	return retval
 }

--- a/client/blast.go
+++ b/client/blast.go
@@ -18,8 +18,8 @@ package main
 import "fmt"
 import "io"
 import "math/rand"
-import "time"
 import "sync"
+import "time"
 
 import "./common"
 import "./f"

--- a/client/common/types.go
+++ b/client/common/types.go
@@ -17,18 +17,10 @@ package common
 
 import "io"
 
-type Op int
-
-const (
-	GET = iota
-	SET
-	TOUCH
-	DELETE
-)
-
 type Prot interface {
 	Set(rw io.ReadWriter, key []byte, value []byte) error
 	Get(rw io.ReadWriter, key []byte) error
+	BatchGet(rw io.ReadWriter, keys [][]byte) error
 	Delete(rw io.ReadWriter, key []byte) error
 	Touch(rw io.ReadWriter, key []byte) error
 }

--- a/client/textprot/prot.go
+++ b/client/textprot/prot.go
@@ -129,6 +129,51 @@ func (t TextProt) Get(rw io.ReadWriter, key []byte) error {
 	return nil
 }
 
+func (t TextProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
+	if VERBOSE {
+		fmt.Printf("Getting keys %v\n", keys)
+	}
+
+	cmd := []byte("get")
+	space := byte(' ')
+
+	for _, key := range keys {
+		cmd = append(cmd, space)
+		cmd = append(cmd, key...)
+	}
+
+	cmd = append(cmd, byte('\r'), byte('\n'))
+
+	_, err := fmt.Fprint(rw, string(cmd))
+	if err != nil {
+		return err
+	}
+
+	for {
+		// read the header line
+		response, err := rl(rw)
+		if err != nil {
+			return err
+		}
+		if VERBOSE {
+			fmt.Println(response)
+		}
+
+		if strings.TrimSpace(response) == "END" {
+			if VERBOSE {
+				fmt.Println("End of batch response")
+			}
+			return nil
+		}
+
+		// then read the value
+		response, err = rl(rw)
+		if err != nil {
+			return err
+		}
+	}
+}
+
 func (t TextProt) Delete(rw io.ReadWriter, key []byte) error {
 	strKey := string(key)
 	if VERBOSE {

--- a/client/textprot/prot.go
+++ b/client/textprot/prot.go
@@ -144,7 +144,7 @@ func (t TextProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
 	}
 
 	cmd = append(cmd, end...)
-	
+
 	_, err := fmt.Fprint(rw, string(cmd))
 	if err != nil {
 		return err

--- a/client/textprot/prot.go
+++ b/client/textprot/prot.go
@@ -136,14 +136,15 @@ func (t TextProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
 
 	cmd := []byte("get")
 	space := byte(' ')
+	end := []byte("\r\n")
 
 	for _, key := range keys {
 		cmd = append(cmd, space)
 		cmd = append(cmd, key...)
 	}
 
-	cmd = append(cmd, byte('\r'), byte('\n'))
-
+	cmd = append(cmd, end...)
+	
 	_, err := fmt.Fprint(rw, string(cmd))
 	if err != nil {
 		return err

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -70,7 +70,7 @@ type Responder interface {
 	Set() error
 	Get(response GetResponse) error
 	GetMiss(response GetResponse) error
-	GetEnd() error
+	GetEnd(noopEnd bool) error
 	Delete() error
 	Touch() error
 	Error(err error) error
@@ -89,6 +89,7 @@ type GetRequest struct {
 	Keys    [][]byte
 	Opaques []uint32
 	Quiet   []bool
+	NoopEnd bool
 }
 
 type DeleteRequest struct {

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -88,6 +88,7 @@ type SetRequest struct {
 type GetRequest struct {
 	Keys    [][]byte
 	Opaques []uint32
+	Quiet   []bool
 }
 
 type DeleteRequest struct {
@@ -106,7 +107,7 @@ type GetResponse struct {
 	Key      []byte
 	Opaque   uint32
 	Metadata Metadata
-	Data     []byte
+	Quiet    bool
 }
 
 const METADATA_SIZE = 32

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -107,6 +107,7 @@ type GetResponse struct {
 	Key      []byte
 	Opaque   uint32
 	Metadata Metadata
+	Data     []byte
 	Quiet    bool
 }
 

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -41,7 +41,7 @@ var (
 // memcached itself
 func IsAppError(err error) bool {
 	return err == ERROR_KEY_NOT_FOUND ||
-		err == ERROR_KEY_EXISTS ||	
+		err == ERROR_KEY_EXISTS ||
 		err == ERROR_VALUE_TOO_BIG ||
 		err == ERROR_INVALID_ARGS ||
 		err == ERROR_ITEM_NOT_STORED ||

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -41,7 +41,7 @@ var (
 // memcached itself
 func IsAppError(err error) bool {
 	return err == ERROR_KEY_NOT_FOUND ||
-		err == ERROR_KEY_EXISTS ||
+		err == ERROR_KEY_EXISTS ||	
 		err == ERROR_VALUE_TOO_BIG ||
 		err == ERROR_INVALID_ARGS ||
 		err == ERROR_ITEM_NOT_STORED ||
@@ -54,11 +54,12 @@ func IsAppError(err error) bool {
 type RequestType int
 
 const (
-	REQUEST_UNKNOWN = RequestType(-1)
-	REQUEST_GET     = RequestType(0)
-	REQUEST_SET     = RequestType(1)
-	REQUEST_DELETE  = RequestType(2)
-	REQUEST_TOUCH   = RequestType(3)
+	REQUEST_UNKNOWN = iota
+	REQUEST_GET
+	REQUEST_GETQ
+	REQUEST_SET
+	REQUEST_DELETE
+	REQUEST_TOUCH
 )
 
 type RequestParser interface {

--- a/local/localHandlers.go
+++ b/local/localHandlers.go
@@ -144,10 +144,10 @@ outer:
 			if err == common.MISS || err == common.ERROR_KEY_NOT_FOUND {
 				//fmt.Println("Get miss because of missing metadata. Key:", key)
 				dataOut <- common.GetResponse{
-					Miss: true,
-					Key:  key,
-					Opaque: cmd.Opaques[idx],
-					Quiet: cmd.Quiet[idx],
+					Miss:     true,
+					Key:      key,
+					Opaque:   cmd.Opaques[idx],
+					Quiet:    cmd.Quiet[idx],
 					Metadata: metaData,
 				}
 				continue outer
@@ -177,10 +177,10 @@ outer:
 				if err == common.MISS || err == common.ERROR_KEY_NOT_FOUND {
 					fmt.Println("Get miss because of missing chunk. Cmd:", getCmd)
 					dataOut <- common.GetResponse{
-						Miss: true,
-						Key:  key,
-						Opaque: cmd.Opaques[idx],
-						Quiet: cmd.Quiet[idx],
+						Miss:     true,
+						Key:      key,
+						Opaque:   cmd.Opaques[idx],
+						Quiet:    cmd.Quiet[idx],
 						Metadata: metaData,
 					}
 					continue outer
@@ -195,10 +195,10 @@ outer:
 				fmt.Printf("Expected: %v\n", metaData.Token)
 				fmt.Printf("Got:      %v\n", tokenBuf)
 				dataOut <- common.GetResponse{
-					Miss: true,
-					Key:  key,
-					Opaque: cmd.Opaques[idx],
-					Quiet: cmd.Quiet[idx],
+					Miss:     true,
+					Key:      key,
+					Opaque:   cmd.Opaques[idx],
+					Quiet:    cmd.Quiet[idx],
 					Metadata: metaData,
 				}
 				continue outer
@@ -206,10 +206,10 @@ outer:
 		}
 
 		dataOut <- common.GetResponse{
-			Miss: false,
-			Key:  key,
-			Opaque: cmd.Opaques[idx],
-			Quiet: cmd.Quiet[idx],
+			Miss:     false,
+			Key:      key,
+			Opaque:   cmd.Opaques[idx],
+			Quiet:    cmd.Quiet[idx],
 			Metadata: metaData,
 			Data:     dataBuf,
 		}

--- a/local/localHandlers.go
+++ b/local/localHandlers.go
@@ -146,7 +146,9 @@ outer:
 				dataOut <- common.GetResponse{
 					Miss: true,
 					Key:  key,
-					//opaque
+					Opaque: cmd.Opaques[idx],
+					Quiet: cmd.Quiet[idx],
+					Metadata: metaData,
 				}
 				continue outer
 			}
@@ -179,7 +181,7 @@ outer:
 						Key:  key,
 						Opaque: cmd.Opaques[idx],
 						Quiet: cmd.Quiet[idx],
-						Metadata: cmd.Metadata,
+						Metadata: metaData,
 					}
 					continue outer
 				}
@@ -197,7 +199,7 @@ outer:
 					Key:  key,
 					Opaque: cmd.Opaques[idx],
 					Quiet: cmd.Quiet[idx],
-					Metadata: cmd.Metadata,
+					Metadata: metaData,
 				}
 				continue outer
 			}
@@ -206,7 +208,8 @@ outer:
 		dataOut <- common.GetResponse{
 			Miss: false,
 			Key:  key,
-			// opaque
+			Opaque: cmd.Opaques[idx],
+			Quiet: cmd.Quiet[idx],
 			Metadata: metaData,
 			Data:     dataBuf,
 		}

--- a/local/localHandlers.go
+++ b/local/localHandlers.go
@@ -137,12 +137,12 @@ func realHandleGet(cmd common.GetRequest, dataOut chan common.GetResponse, error
 	defer close(dataOut)
 
 outer:
-	for _, key := range cmd.Keys {
+	for idx, key := range cmd.Keys {
 		_, metaData, err := getMetadata(localReader, localWriter, key)
 		if err != nil {
 			// TODO: Better error management
 			if err == common.MISS || err == common.ERROR_KEY_NOT_FOUND {
-				fmt.Println("Get miss because of missing metadata. Key:", key)
+				//fmt.Println("Get miss because of missing metadata. Key:", key)
 				dataOut <- common.GetResponse{
 					Miss: true,
 					Key:  key,
@@ -177,7 +177,9 @@ outer:
 					dataOut <- common.GetResponse{
 						Miss: true,
 						Key:  key,
-						//opaque
+						Opaque: cmd.Opaques[idx],
+						Quiet: cmd.Quiet[idx],
+						Metadata: cmd.Metadata,
 					}
 					continue outer
 				}
@@ -193,7 +195,9 @@ outer:
 				dataOut <- common.GetResponse{
 					Miss: true,
 					Key:  key,
-					//opaque
+					Opaque: cmd.Opaques[idx],
+					Quiet: cmd.Quiet[idx],
+					Metadata: cmd.Metadata,
 				}
 				continue outer
 			}

--- a/memproxy.go
+++ b/memproxy.go
@@ -26,9 +26,8 @@ import "io"
 import "net"
 import "os"
 import "os/signal"
-
- import "runtime"
- import "strings"
+import "runtime"
+import "strings"
 
 import "./binprot"
 import "./common"
@@ -193,7 +192,8 @@ func handleConnectionReal(remoteConn, localConn net.Conn) {
 			}
 
 		case common.REQUEST_GET:
-			resChan, errChan := local.HandleGet(request.(common.GetRequest), localReader, localWriter)
+			getReq := request.(common.GetRequest)
+			resChan, errChan := local.HandleGet(getReq, localReader, localWriter)
 
 			for {
 				select {
@@ -221,7 +221,7 @@ func handleConnectionReal(remoteConn, localConn net.Conn) {
 				}
 			}
 
-			responder.GetEnd()
+			responder.GetEnd(getReq.NoopEnd)
 
 		case common.REQUEST_UNKNOWN:
 			err = common.ERROR_UNKNOWN_CMD

--- a/textprot/parser.go
+++ b/textprot/parser.go
@@ -107,10 +107,12 @@ func (t TextParser) Parse() (interface{}, common.RequestType, error) {
 		}
 
 		opaques := make([]uint32, len(keys))
+		quiet := make([]bool, len(keys))
 
 		return common.GetRequest{
 			Keys:    keys,
 			Opaques: opaques,
+			Quiet:   quiet,
 		}, common.REQUEST_GET, nil
 
 	case "delete":

--- a/textprot/parser.go
+++ b/textprot/parser.go
@@ -113,6 +113,7 @@ func (t TextParser) Parse() (interface{}, common.RequestType, error) {
 			Keys:    keys,
 			Opaques: opaques,
 			Quiet:   quiet,
+			NoopEnd: false,
 		}, common.REQUEST_GET, nil
 
 	case "delete":

--- a/textprot/respond.go
+++ b/textprot/respond.go
@@ -79,7 +79,7 @@ func (t TextResponder) GetMiss(response common.GetResponse) error {
 	return nil
 }
 
-func (t TextResponder) GetEnd() error {
+func (t TextResponder) GetEnd(noopEnd bool) error {
 	_, err := fmt.Fprintf(t.writer, "END\r\n")
 	if err != nil {
 		return err


### PR DESCRIPTION
Batch gets are native to the text protocol, but not to the binary protocol. An optimization for binary communication is to send a batch of gets as a pipelined set of GETQ commands, followed by either a final GET or a NOOP in order to guarantee a response. This branch implements this optimization in the binary protocol parser.

As well, there were numerous bugs found on the way, including issue #9, that needed to be fixed. Some bugs were there before the branch and have been found through testing. The internal representation of gets had to be changed a bit, which is why there's some changes in the text protocol package as well.

In order to test the new functionality, the blast script has been updated to send batch gets as well as get, set, delete, and touch commands. The implementation has been tested against memcached prior to being tested against the memproxy program.