### PR TITLE
Cmd get and touch

### DIFF
--- a/binprot/commands.go
+++ b/binprot/commands.go
@@ -39,20 +39,28 @@ func SetCmd(key []byte, flags, exptime, dataSize uint32) []byte {
 	//return fmt.Sprintf("set %s 0 %s %d\r\n", key, exptime, size)
 }
 
-func GetCmd(key []byte, shouldTouch bool) []byte {
-	var opcode int
-	if shouldTouch {
-		opcode = OPCODE_GAT
-	} else {
-		opcode = OPCODE_GET
-	}
-
+func GetCmd(key []byte) []byte {
 	// opcode, keyLength, extraLength, totalBodyLength
-	header := MakeRequestHeader(opcode, len(key), 0, len(key))
+	header := MakeRequestHeader(OPCODE_GET, len(key), 0, len(key))
 
 	reqBuf := new(bytes.Buffer)
 	binary.Write(reqBuf, binary.BigEndian, header)
 
+	binary.Write(reqBuf, binary.BigEndian, key)
+
+	return reqBuf.Bytes()
+
+	//return fmt.Sprintf("get %s\r\n", key)
+}
+
+func GATCmd(key []byte, exptime uint32) []byte {
+	// opcode, keyLength, extraLength, totalBodyLength
+	header := MakeRequestHeader(OPCODE_GAT, len(key), 4, len(key))
+
+	reqBuf := new(bytes.Buffer)
+	binary.Write(reqBuf, binary.BigEndian, header)
+
+	binary.Write(reqBuf, binary.BigEndian, exptime)
 	binary.Write(reqBuf, binary.BigEndian, key)
 
 	return reqBuf.Bytes()

--- a/binprot/commands.go
+++ b/binprot/commands.go
@@ -39,9 +39,16 @@ func SetCmd(key []byte, flags, exptime, dataSize uint32) []byte {
 	//return fmt.Sprintf("set %s 0 %s %d\r\n", key, exptime, size)
 }
 
-func GetCmd(key []byte) []byte {
+func GetCmd(key []byte, shouldTouch bool) []byte {
+	var opcode int
+	if shouldTouch {
+		opcode = OPCODE_GAT
+	} else {
+		opcode = OPCODE_GET
+	}
+
 	// opcode, keyLength, extraLength, totalBodyLength
-	header := MakeRequestHeader(OPCODE_GET, len(key), 0, len(key))
+	header := MakeRequestHeader(opcode, len(key), 0, len(key))
 
 	reqBuf := new(bytes.Buffer)
 	binary.Write(reqBuf, binary.BigEndian, header)

--- a/binprot/parser.go
+++ b/binprot/parser.go
@@ -192,6 +192,28 @@ func (b BinaryParser) Parse() (interface{}, common.RequestType, error) {
 			NoopEnd: false,
 		}, common.REQUEST_GET, nil
 
+	case OPCODE_GAT:
+		// exptime, key
+		exptime, err := readUInt32(b.reader)
+
+		if err != nil {
+			fmt.Println("Error reading exptime")
+			return nil, common.REQUEST_GAT, err
+		}
+
+		key, err := readString(b.reader, reqHeader.KeyLength)
+
+		if err != nil {
+			fmt.Println("Error reading key")
+			return nil, common.REQUEST_GAT, err
+		}
+
+		return common.GATRequest {
+			Key: key,
+			Exptime: exptime,
+			Opaque: reqHeader.OpaqueToken,
+		}, common.REQUEST_GAT, nil
+
 	case OPCODE_DELETE:
 		// key
 		key, err := readString(b.reader, reqHeader.KeyLength)

--- a/binprot/parser.go
+++ b/binprot/parser.go
@@ -208,10 +208,10 @@ func (b BinaryParser) Parse() (interface{}, common.RequestType, error) {
 			return nil, common.REQUEST_GAT, err
 		}
 
-		return common.GATRequest {
-			Key: key,
+		return common.GATRequest{
+			Key:     key,
 			Exptime: exptime,
-			Opaque: reqHeader.OpaqueToken,
+			Opaque:  reqHeader.OpaqueToken,
 		}, common.REQUEST_GAT, nil
 
 	case OPCODE_DELETE:

--- a/binprot/respond.go
+++ b/binprot/respond.go
@@ -144,6 +144,14 @@ func (b BinaryResponder) GAT(response common.GetResponse) error {
 	return getCommon(b.writer, response, OPCODE_GAT)
 }
 
+func (b BinaryResponder) GATMiss(response common.GetResponse) error {
+	if !response.Quiet {
+		header := makeErrorResponseHeader(OPCODE_GAT, int(STATUS_KEY_ENOENT), 0)
+		return writeHeader(header, b.writer)
+	}
+	return nil
+}
+
 func (b BinaryResponder) Delete() error {
 	header := makeSuccessResponseHeader(OPCODE_DELETE, 0, 0, 0, 0)
 	return writeHeader(header, b.writer)

--- a/client/binprot/prot.go
+++ b/client/binprot/prot.go
@@ -119,7 +119,7 @@ func (b BinProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
 
 func (b BinProt) GAT(rw io.ReadWriter, key []byte) error {
 	// Header
-	writeReq(rw, GAT, len(key), 0, len(key))
+	writeReq(rw, GAT, len(key), 4, len(key))
 	// Extras
 	binary.Write(rw, binary.BigEndian, common.Exp())
 	// Body

--- a/client/binprot/prot.go
+++ b/client/binprot/prot.go
@@ -117,6 +117,16 @@ func (b BinProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
 	return consumeBatchResponse(rw)
 }
 
+func (b BinProt) GAT(rw io.ReadWriter, key []byte) error {
+	// Header
+	writeReq(rw, GAT, len(key), 0, len(key))
+	// Body
+	rw.Write(key)
+
+	// consume all of the response and discard
+	return consumeResponse(rw)
+}
+
 func (b BinProt) Delete(rw io.ReadWriter, key []byte) error {
 	// Header
 	writeReq(rw, Delete, len(key), 0, len(key))

--- a/client/binprot/prot.go
+++ b/client/binprot/prot.go
@@ -120,6 +120,8 @@ func (b BinProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
 func (b BinProt) GAT(rw io.ReadWriter, key []byte) error {
 	// Header
 	writeReq(rw, GAT, len(key), 0, len(key))
+	// Extras
+	binary.Write(rw, binary.BigEndian, common.Exp())
 	// Body
 	rw.Write(key)
 

--- a/client/binprot/prot.go
+++ b/client/binprot/prot.go
@@ -38,15 +38,12 @@ func consumeResponse(r io.Reader) error {
 	if apperr != nil && srsErr(apperr) {
 		return apperr
 	}
-	if err == io.EOF {
-		return nil
-	}
+
 	return err
 }
 
 func consumeBatchResponse(r io.Reader) error {
-	opcode := uint8(0x09)
-	var err error
+	opcode := uint8(Get)
 	var apperr error
 
 	for opcode != Noop {
@@ -61,16 +58,8 @@ func consumeBatchResponse(r io.Reader) error {
 		// read body in regardless of the error in the header
 		lr := io.LimitReader(r, int64(res.BodyLen))
 		io.Copy(ioutil.Discard, lr)
-
-		// connection closed
-		if err == io.EOF {
-			return nil
-		}
 	}
 
-	if err != nil {
-		return err
-	}
 	return apperr
 }
 

--- a/client/blast.go
+++ b/client/blast.go
@@ -37,7 +37,7 @@ func main() {
 	var numCmds int
 	var usedCmds string
 	var protString string
-	
+
 	if f.Binary {
 		var b binprot.BinProt
 		prot = b

--- a/client/blast.go
+++ b/client/blast.go
@@ -36,20 +36,23 @@ func main() {
 	var prot common.Prot
 	var numCmds int
 	var usedCmds string
+	var protString string
 	
 	if f.Binary {
 		var b binprot.BinProt
 		prot = b
 		numCmds = 6
 		usedCmds = "get, batch get, get and touch, set, touch, delete"
+		protString = "binary"
 	} else {
 		var t textprot.TextProt
 		prot = t
 		numCmds = 5
 		usedCmds = "get, batch get, set, touch, delete"
+		protString = "text"
 	}
 
-	fmt.Printf("Performing %v operations total\n\twith %v communication goroutines\n\tusing commands %v\n\n", f.NumOps, f.NumWorkers, usedCmds)
+	fmt.Printf("Performing %v operations total with:\n\t%v communication goroutines\n\tcommands %v\n\tover the %v protocol\n\n", f.NumOps, f.NumWorkers, usedCmds, protString)
 
 	tasks := make(chan *common.Task)
 	taskGens := new(sync.WaitGroup)

--- a/client/common/types.go
+++ b/client/common/types.go
@@ -18,8 +18,11 @@ package common
 import "io"
 
 type Prot interface {
+	// Yes, the abstraction is a little bit leaky, but the code
+	// in other places benefits from the consistency.
 	Set(rw io.ReadWriter, key []byte, value []byte) error
 	Get(rw io.ReadWriter, key []byte) error
+	GAT(rw io.ReadWriter, key []byte) error
 	BatchGet(rw io.ReadWriter, keys [][]byte) error
 	Delete(rw io.ReadWriter, key []byte) error
 	Touch(rw io.ReadWriter, key []byte) error

--- a/client/textprot/prot.go
+++ b/client/textprot/prot.go
@@ -175,6 +175,13 @@ func (t TextProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
 	}
 }
 
+
+func (t TextProt) GAT(rw io.ReadWriter, key []byte) error {
+	// Yes, the abstraction is a little bit leaky, but the code
+	// in other places benefits from the consistency.
+	panic("GAT in text protocol")
+}
+
 func (t TextProt) Delete(rw io.ReadWriter, key []byte) error {
 	strKey := string(key)
 	if VERBOSE {

--- a/client/textprot/prot.go
+++ b/client/textprot/prot.go
@@ -175,7 +175,6 @@ func (t TextProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
 	}
 }
 
-
 func (t TextProt) GAT(rw io.ReadWriter, key []byte) error {
 	// Yes, the abstraction is a little bit leaky, but the code
 	// in other places benefits from the consistency.

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -57,6 +57,7 @@ const (
 	REQUEST_UNKNOWN = iota
 	REQUEST_GET
 	REQUEST_GETQ
+	REQUEST_GAT
 	REQUEST_SET
 	REQUEST_DELETE
 	REQUEST_TOUCH
@@ -71,6 +72,7 @@ type Responder interface {
 	Get(response GetResponse) error
 	GetMiss(response GetResponse) error
 	GetEnd(noopEnd bool) error
+	GAT(response GetResponse) error
 	Delete() error
 	Touch() error
 	Error(err error) error
@@ -98,6 +100,12 @@ type DeleteRequest struct {
 }
 
 type TouchRequest struct {
+	Key     []byte
+	Exptime uint32
+	Opaque  uint32
+}
+
+type GATRequest struct {
 	Key     []byte
 	Exptime uint32
 	Opaque  uint32

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -73,6 +73,7 @@ type Responder interface {
 	GetMiss(response GetResponse) error
 	GetEnd(noopEnd bool) error
 	GAT(response GetResponse) error
+	GATMiss(response GetResponse) error
 	Delete() error
 	Touch() error
 	Error(err error) error

--- a/local/localComm.go
+++ b/local/localComm.go
@@ -53,14 +53,12 @@ func getMetadataCommon(localReader *bufio.Reader, localWriter *bufio.Writer, get
 
 	err = binprot.DecodeError(resHeader)
 	if err != nil {
-		if err == common.ERROR_KEY_NOT_FOUND {
-			// read in the message "Not found" after a miss
-			lr := io.LimitReader(localReader, int64(resHeader.TotalBodyLength))
-			_, ioerr := io.Copy(ioutil.Discard, lr)
+		// read in the message "Not found" after a miss
+		lr := io.LimitReader(localReader, int64(resHeader.TotalBodyLength))
+		_, ioerr := io.Copy(ioutil.Discard, lr)
 
-			if ioerr != nil {
-				return common.Metadata{}, ioerr
-			}
+		if ioerr != nil {
+			return common.Metadata{}, ioerr
 		}
 
 		return common.Metadata{}, err
@@ -118,13 +116,11 @@ func simpleCmdLocal(localReader *bufio.Reader, localWriter *bufio.Writer, cmd []
 
 	err = binprot.DecodeError(resHeader)
 	if err != nil {
-		if err == common.ERROR_KEY_NOT_FOUND {
-			lr := io.LimitReader(localReader, int64(resHeader.TotalBodyLength))
-			_, ioerr := io.Copy(ioutil.Discard, lr)
+		lr := io.LimitReader(localReader, int64(resHeader.TotalBodyLength))
+		_, ioerr := io.Copy(ioutil.Discard, lr)
 
-			if ioerr != nil {
-				return ioerr
-			}
+		if ioerr != nil {
+			return ioerr
 		}
 		return err
 	}
@@ -154,13 +150,11 @@ func getLocalIntoBuf(localReader *bufio.Reader, localWriter *bufio.Writer,
 
 	err = binprot.DecodeError(resHeader)
 	if err != nil {
-		if err == common.ERROR_KEY_NOT_FOUND {
-			lr := io.LimitReader(localReader, int64(resHeader.TotalBodyLength))
-			_, ioerr := io.Copy(ioutil.Discard, lr)
+		lr := io.LimitReader(localReader, int64(resHeader.TotalBodyLength))
+		_, ioerr := io.Copy(ioutil.Discard, lr)
 
-			if ioerr != nil {
-				return ioerr
-			}
+		if ioerr != nil {
+			return ioerr
 		}
 		return err
 	}

--- a/local/localComm.go
+++ b/local/localComm.go
@@ -26,11 +26,11 @@ import "io/ioutil"
 import "../binprot"
 import "../common"
 
-func getMetadata(localReader *bufio.Reader, localWriter *bufio.Writer, key []byte) ([]byte, common.Metadata, error) {
+func getMetadata(localReader *bufio.Reader, localWriter *bufio.Writer, key []byte, shouldTouch bool) ([]byte, common.Metadata, error) {
 	metaKey := metaKey(key)
 
 	// Read in the metadata for number of chunks, chunk size, etc.
-	getCmd := binprot.GetCmd(metaKey)
+	getCmd := binprot.GetCmd(metaKey, shouldTouch)
 
 	_, err := localWriter.Write(getCmd)
 	if err != nil {

--- a/memproxy.go
+++ b/memproxy.go
@@ -90,7 +90,7 @@ func identifyPanic() string {
 	var name, file string
 	var line int
 	var pc [16]uintptr
-	
+
 	n := runtime.Callers(3, pc[:])
 	for _, pc := range pc[:n] {
 		fn := runtime.FuncForPC(pc)
@@ -103,7 +103,7 @@ func identifyPanic() string {
 			break
 		}
 	}
-	
+
 	return fmt.Sprintf("%v:%v:%v", file, name, line)
 }
 

--- a/memproxy.go
+++ b/memproxy.go
@@ -223,6 +223,14 @@ func handleConnectionReal(remoteConn, localConn net.Conn) {
 
 			responder.GetEnd(getReq.NoopEnd)
 
+		case common.REQUEST_GAT:
+			res, err := local.HandleGAT(request.(common.GATRequest), localReader, localWriter)
+
+			if err != nil {
+				responder.GAT(res)
+				responder.GetEnd(false)
+			}
+
 		case common.REQUEST_UNKNOWN:
 			err = common.ERROR_UNKNOWN_CMD
 		}

--- a/memproxy.go
+++ b/memproxy.go
@@ -226,9 +226,13 @@ func handleConnectionReal(remoteConn, localConn net.Conn) {
 		case common.REQUEST_GAT:
 			res, err := local.HandleGAT(request.(common.GATRequest), localReader, localWriter)
 
-			if err != nil {
-				responder.GAT(res)
-				responder.GetEnd(false)
+			if err == nil {
+				if res.Miss {
+					responder.GATMiss(res)
+				} else {
+					responder.GAT(res)
+					responder.GetEnd(false)
+				}
 			}
 
 		case common.REQUEST_UNKNOWN:

--- a/textprot/respond.go
+++ b/textprot/respond.go
@@ -100,6 +100,10 @@ func (t TextResponder) GAT(response common.GetResponse) error {
 	panic("GAT command in text protocol")
 }
 
+func (t TextResponder) GATMiss(response common.GetResponse) error {
+	panic("GAT command in text protocol")
+}
+
 func (t TextResponder) Delete() error {
 	_, err := fmt.Fprintf(t.writer, "DELETED\r\n")
 	if err != nil {

--- a/textprot/respond.go
+++ b/textprot/respond.go
@@ -89,6 +89,17 @@ func (t TextResponder) GetEnd(noopEnd bool) error {
 	return nil
 }
 
+func (t TextResponder) GAT(response common.GetResponse) error {
+	// There's two options here.
+	// 1) panic() because this is never supposed to be called
+	// 2) Respond as a normal get
+	//
+	// I chose to panic, since this means we are in a bad state.
+	// The text parser will never return a GAT command because
+	// it does not exist in the text protocol.
+	panic("GAT command in text protocol")
+}
+
 func (t TextResponder) Delete() error {
 	_, err := fmt.Fprintf(t.writer, "DELETED\r\n")
 	if err != nil {


### PR DESCRIPTION
Get-and-touch command implemented. The GAT command only exists in the binary protocol, so the abstraction isn't quite perfect. The text parser will never return a GAT command, and the responder panics if it gets one.

Testing at this point has revealed a very rare bug with sets causing inconsistent state, but that is outside the purview of this branch. 

This pull request will close #16 