### PR TITLE
Cleaning up local IO interfaces

### DIFF
--- a/stream/chunkedLimitedReader.go
+++ b/stream/chunkedLimitedReader.go
@@ -18,7 +18,7 @@ package stream
 import "io"
 import "math"
 
-func ChunkLimitReader(reader io.Reader, chunkSize, totalSize int64) ChunkedLimitedReader {
+func NewChunkLimitedReader(reader io.Reader, chunkSize, totalSize int64) ChunkedLimitedReader {
 	numChunks := int64(math.Ceil(float64(totalSize) / float64(chunkSize)))
 	return ChunkedLimitedReader{
 		d: &clrData{


### PR DESCRIPTION
* Using buffo.ReadWriter instead of separate reader and writer
* More terse variables
* Use of Discard() instead of setting up limited readers
* Idiomatic if statements / error checking