### PR TITLE
Blast telemetry and improvements

### DIFF
--- a/client/blast.go
+++ b/client/blast.go
@@ -1,24 +1,26 @@
-/**
- * Copyright 2015 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2015 Netflix, Inc.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+ 
 package main
 
+import "bufio"
 import "fmt"
 import "io"
 import "math/rand"
 import "net"
+import "os"
+import "runtime/pprof"
 import "sync"
 import "time"
 
@@ -28,12 +30,16 @@ import _ "./sigs"
 import "./binprot"
 import "./textprot"
 
-// Package init
-func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
-}
-
 func main() {
+	if f.Pprof != "" {
+		f, err := os.Create(f.Pprof)
+		if err != nil {
+			panic(err.Error())
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+	}
+
 	var prot common.Prot
 	var numCmds int
 	var usedCmds string
@@ -105,11 +111,13 @@ func main() {
 }
 
 func cmdGenerator(tasks chan<- *common.Task, taskGens *sync.WaitGroup, numTasks int, cmd string) {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+
 	for i := 0; i < numTasks; i++ {
 		tasks <- &common.Task{
 			Cmd:   cmd,
-			Key:   common.RandData(f.KeyLength),
-			Value: taskValue(cmd),
+			Key:   common.RandData(r, f.KeyLength),
+			Value: taskValue(r, cmd),
 		}
 	}
 
@@ -117,33 +125,36 @@ func cmdGenerator(tasks chan<- *common.Task, taskGens *sync.WaitGroup, numTasks 
 	taskGens.Done()
 }
 
-func taskValue(cmd string) []byte {
+func taskValue(r *rand.Rand, cmd string) []byte {
 	if cmd == "set" {
 		// Random length between 1k and 10k
-		valLen := rand.Intn(9*1024) + 1024
-		return common.RandData(valLen)
+		valLen := r.Intn(9*1024) + 1024
+		return common.RandData(r, valLen)
 	}
 
 	return nil
 }
 
 func communicator(prot common.Prot, conn net.Conn, tasks <-chan *common.Task, comms *sync.WaitGroup) {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	rw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
+
 	for item := range tasks {
 		var err error
 
 		switch item.Cmd {
 		case "set":
-			err = prot.Set(conn, item.Key, item.Value)
+			err = prot.Set(rw, item.Key, item.Value)
 		case "get":
-			err = prot.Get(conn, item.Key)
+			err = prot.Get(rw, item.Key)
 		case "gat":
-			err = prot.GAT(conn, item.Key)
+			err = prot.GAT(rw, item.Key)
 		case "bget":
-			err = prot.BatchGet(conn, batchkeys(item.Key))
+			err = prot.BatchGet(rw, batchkeys(r, item.Key))
 		case "delete":
-			err = prot.Delete(conn, item.Key)
+			err = prot.Delete(rw, item.Key)
 		case "touch":
-			err = prot.Touch(conn, item.Key)
+			err = prot.Touch(rw, item.Key)
 		}
 
 		if err != nil {
@@ -162,10 +173,10 @@ func communicator(prot common.Prot, conn net.Conn, tasks <-chan *common.Task, co
 	comms.Done()
 }
 
-func batchkeys(key []byte) [][]byte {
+func batchkeys(r *rand.Rand, key []byte) [][]byte {
 	key = key[1:]
 	retval := make([][]byte, 0)
-	numKeys := rand.Intn(25) + 2 + int('A')
+	numKeys := r.Intn(25) + 2 + int('A')
 
 	for i := int('A'); i < numKeys; i++ {
 		retval = append(retval, append([]byte{byte(i)}, key...))

--- a/client/blast.go
+++ b/client/blast.go
@@ -1,17 +1,17 @@
 // Copyright 2015 Netflix, Inc.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
- 
+
 package main
 
 import "bufio"
@@ -21,14 +21,21 @@ import "math/rand"
 import "net"
 import "os"
 import "runtime/pprof"
+import "sort"
 import "sync"
 import "time"
 
 import "./common"
 import "./f"
 import _ "./sigs"
+import "./stats"
 import "./binprot"
 import "./textprot"
+
+type metric struct {
+	d  time.Duration
+	op common.Op
+}
 
 func main() {
 	if f.Pprof != "" {
@@ -68,17 +75,20 @@ func main() {
 	// TODO: Better math
 	opsPerTask := f.NumOps / numCmds / f.NumWorkers
 
+	// HUGE channel so the comm threads never block
+	metrics := make(chan metric, f.NumOps)
+
 	// spawn task generators
 	for i := 0; i < f.NumWorkers; i++ {
 		taskGens.Add(numCmds)
-		go cmdGenerator(tasks, taskGens, opsPerTask, "set")
-		go cmdGenerator(tasks, taskGens, opsPerTask, "get")
-		go cmdGenerator(tasks, taskGens, opsPerTask, "bget")
-		go cmdGenerator(tasks, taskGens, opsPerTask, "delete")
-		go cmdGenerator(tasks, taskGens, opsPerTask, "touch")
+		go cmdGenerator(tasks, taskGens, opsPerTask, common.Set)
+		go cmdGenerator(tasks, taskGens, opsPerTask, common.Get)
+		go cmdGenerator(tasks, taskGens, opsPerTask, common.Bget)
+		go cmdGenerator(tasks, taskGens, opsPerTask, common.Delete)
+		go cmdGenerator(tasks, taskGens, opsPerTask, common.Touch)
 
 		if f.Binary {
-			go cmdGenerator(tasks, taskGens, opsPerTask, "gat")
+			go cmdGenerator(tasks, taskGens, opsPerTask, common.Gat)
 		}
 	}
 
@@ -93,7 +103,7 @@ func main() {
 			continue
 		}
 
-		go communicator(prot, conn, tasks, comms)
+		go communicator(prot, conn, tasks, metrics, comms)
 	}
 
 	// First wait for all the tasks to be generated,
@@ -108,9 +118,42 @@ func main() {
 	comms.Wait()
 
 	fmt.Println("Comms done.")
+	close(metrics)
+
+	// consolidate some metrics
+	// bucketize the timings based on operation
+	// print min, max, average, 50%, 90%
+	cons := make(map[common.Op][]int)
+	for m := range metrics {
+		if _, ok := cons[m.op]; ok {
+			cons[m.op] = append(cons[m.op], int(m.d.Nanoseconds()))
+		} else {
+			cons[m.op] = []int{int(m.d.Nanoseconds())}
+		}
+	}
+
+	for _, op := range common.AllOps {
+		times := cons[op]
+		sort.Ints(times)
+		s := stats.Get(times)
+
+		fmt.Println()
+		fmt.Println(op.String())
+		fmt.Printf("Min: %fms\n", s.Min)
+		fmt.Printf("Max: %fms\n", s.Max)
+		fmt.Printf("Avg: %fms\n", s.Avg)
+		fmt.Printf("p50: %fms\n", s.P50)
+		fmt.Printf("p75: %fms\n", s.P75)
+		fmt.Printf("p90: %fms\n", s.P90)
+		fmt.Printf("p95: %fms\n", s.P95)
+		fmt.Printf("p99: %fms\n", s.P99)
+		fmt.Println()
+
+		stats.PrintHist(times)
+	}
 }
 
-func cmdGenerator(tasks chan<- *common.Task, taskGens *sync.WaitGroup, numTasks int, cmd string) {
+func cmdGenerator(tasks chan<- *common.Task, taskGens *sync.WaitGroup, numTasks int, cmd common.Op) {
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 
 	for i := 0; i < numTasks; i++ {
@@ -121,12 +164,11 @@ func cmdGenerator(tasks chan<- *common.Task, taskGens *sync.WaitGroup, numTasks 
 		}
 	}
 
-	fmt.Println(cmd, "gen done")
 	taskGens.Done()
 }
 
-func taskValue(r *rand.Rand, cmd string) []byte {
-	if cmd == "set" {
+func taskValue(r *rand.Rand, cmd common.Op) []byte {
+	if cmd == common.Set {
 		// Random length between 1k and 10k
 		valLen := r.Intn(9*1024) + 1024
 		return common.RandData(r, valLen)
@@ -135,25 +177,26 @@ func taskValue(r *rand.Rand, cmd string) []byte {
 	return nil
 }
 
-func communicator(prot common.Prot, conn net.Conn, tasks <-chan *common.Task, comms *sync.WaitGroup) {
+func communicator(prot common.Prot, conn net.Conn, tasks <-chan *common.Task, metrics chan<- metric, comms *sync.WaitGroup) {
 	r := rand.New(rand.NewSource(time.Now().Unix()))
 	rw := bufio.NewReadWriter(bufio.NewReader(conn), bufio.NewWriter(conn))
 
 	for item := range tasks {
 		var err error
+		start := time.Now()
 
 		switch item.Cmd {
-		case "set":
+		case common.Set:
 			err = prot.Set(rw, item.Key, item.Value)
-		case "get":
+		case common.Get:
 			err = prot.Get(rw, item.Key)
-		case "gat":
+		case common.Gat:
 			err = prot.GAT(rw, item.Key)
-		case "bget":
+		case common.Bget:
 			err = prot.BatchGet(rw, batchkeys(r, item.Key))
-		case "delete":
+		case common.Delete:
 			err = prot.Delete(rw, item.Key)
-		case "touch":
+		case common.Touch:
 			err = prot.Touch(rw, item.Key)
 		}
 
@@ -166,10 +209,14 @@ func communicator(prot common.Prot, conn net.Conn, tasks <-chan *common.Task, co
 				break
 			}
 		}
+
+		metrics <- metric{
+			d:  time.Since(start),
+			op: item.Cmd,
+		}
 	}
 
 	conn.Close()
-	fmt.Println("comm done")
 	comms.Done()
 }
 

--- a/client/blast.go
+++ b/client/blast.go
@@ -133,6 +133,10 @@ func main() {
 	}
 
 	for _, op := range common.AllOps {
+		if f.Text &&  op == common.Gat {
+			continue
+		}
+
 		times := cons[op]
 		sort.Ints(times)
 		s := stats.Get(times)

--- a/client/common/types.go
+++ b/client/common/types.go
@@ -27,8 +27,44 @@ type Prot interface {
 	Touch(rw *bufio.ReadWriter, key []byte) error
 }
 
+type Op int
+
+const (
+	Get = iota
+	Bget
+	Gat
+	Set
+	Touch
+	Delete
+)
+
+var AllOps []Op
+
+func init() {
+	AllOps = []Op{Get, Bget, Gat, Set, Touch, Delete}
+}
+
+func (o Op) String() string {
+	switch o {
+	case Set:
+		return "Set"
+	case Get:
+		return "Get"
+	case Gat:
+		return "Get and Touch"
+	case Bget:
+		return "Batch Get"
+	case Delete:
+		return "Delete"
+	case Touch:
+		return "Touch"
+	default:
+		return ""
+	}
+}
+
 type Task struct {
-	Cmd   string
+	Cmd   Op
 	Key   []byte
 	Value []byte
 }

--- a/client/common/types.go
+++ b/client/common/types.go
@@ -1,31 +1,30 @@
-/**
- * Copyright 2015 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package common
 
-import "io"
+import "bufio"
 
 type Prot interface {
 	// Yes, the abstraction is a little bit leaky, but the code
 	// in other places benefits from the consistency.
-	Set(rw io.ReadWriter, key []byte, value []byte) error
-	Get(rw io.ReadWriter, key []byte) error
-	GAT(rw io.ReadWriter, key []byte) error
-	BatchGet(rw io.ReadWriter, keys [][]byte) error
-	Delete(rw io.ReadWriter, key []byte) error
-	Touch(rw io.ReadWriter, key []byte) error
+	Set(rw *bufio.ReadWriter, key []byte, value []byte) error
+	Get(rw *bufio.ReadWriter, key []byte) error
+	GAT(rw *bufio.ReadWriter, key []byte) error
+	BatchGet(rw *bufio.ReadWriter, keys [][]byte) error
+	Delete(rw *bufio.ReadWriter, key []byte) error
+	Touch(rw *bufio.ReadWriter, key []byte) error
 }
 
 type Task struct {

--- a/client/common/utils.go
+++ b/client/common/utils.go
@@ -25,10 +25,12 @@ import "time"
 var letters = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 const PREDATA_LENGTH = 20 * 1024
+
 var predata []byte
+
 func init() {
 	r := rand.New(rand.NewSource(time.Now().Unix()))
-	predata = RandData(r, PREDATA_LENGTH + 1)
+	predata = RandData(r, PREDATA_LENGTH+1)
 }
 
 func RandData(r *rand.Rand, n int) []byte {

--- a/client/common/utils.go
+++ b/client/common/utils.go
@@ -24,11 +24,22 @@ import "time"
 // No constant arrays :(
 var letters = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
-func RandData(n int) []byte {
+const PREDATA_LENGTH = 20 * 1024
+var predata []byte
+func init() {
+	r := rand.New(rand.NewSource(time.Now().Unix()))
+	predata = RandData(r, PREDATA_LENGTH + 1)
+}
+
+func RandData(r *rand.Rand, n int) []byte {
+	if n <= PREDATA_LENGTH {
+		return predata[:n]
+	}
+
 	b := make([]byte, n)
 
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[r.Intn(len(letters))]
 	}
 
 	return b

--- a/client/f/flags.go
+++ b/client/f/flags.go
@@ -1,18 +1,17 @@
-/**
- * Copyright 2015 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package f
 
 import "flag"
@@ -29,6 +28,7 @@ var KeyLength int
 var NumOps int
 var NumWorkers int
 var Port int
+var Pprof string
 
 // Flags
 func init() {
@@ -49,6 +49,8 @@ func init() {
 
 	flag.IntVar(&Port, "port", 11212, "Port to connect to.")
 	flag.IntVar(&Port, "p", 11212, "Port to connect to. (shorthand)")
+
+	flag.StringVar(&Pprof, "pprof", "", "File to be filled with pprof sampling data")
 
 	flag.Parse()
 

--- a/client/stats/stats.go
+++ b/client/stats/stats.go
@@ -1,0 +1,118 @@
+package stats
+
+import "fmt"
+import "math"
+
+type Stats struct {
+	Avg float64
+	Min float64
+	Max float64
+	P50 float64
+	P75 float64
+	P90 float64
+	P95 float64
+	P99 float64
+}
+
+const msFactor = 1000000
+
+// Accepts a sorted slice of durations in nanoseconds
+// Returns a Stats struct of millisecond statistics
+func Get(data []int) Stats {
+	min, max := minmax(data)
+
+	return Stats{
+		Avg: avg(data) / msFactor,
+		Min: min / msFactor,
+		Max: max / msFactor,
+		P50: p(data, 0.5) / msFactor,
+		P75: p(data, 0.75) / msFactor,
+		P90: p(data, 0.9) / msFactor,
+		P95: p(data, 0.95) / msFactor,
+		P99: p(data, 0.99) / msFactor,
+	}
+}
+
+func minmax(data []int) (float64, float64) {
+	min := int(math.MaxInt64)
+	max := int(math.MinInt64)
+	for _, d := range data {
+		if d < min {
+			min = d
+		}
+		if d > max {
+			max = d
+		}
+	}
+	return float64(min), float64(max)
+}
+
+func avg(data []int) float64 {
+	sum := float64(0)
+	for _, d := range data {
+		sum += float64(d)
+	}
+	return sum / float64(len(data))
+}
+
+func p(data []int, p float64) float64 {
+	idx := int(math.Ceil(float64(len(data)) * p))
+	return float64(data[idx])
+}
+
+const numBuckets = 100
+const maxHeight = 50
+
+// Accepts a sorted slice of durations in nanoseconds
+// Prints a histogram to stdout
+func PrintHist(data []int) error {
+	// bucketize
+	buckets := make([]int, numBuckets)
+	min, max := minmax(data)
+	step := (max - min) / numBuckets
+	prevCutIdx := 0
+	maxBucket := 0
+
+	for i := 0; i < numBuckets; i++ {
+		cut := min + step*float64(i+1)
+		count := 0
+		j := prevCutIdx
+
+		for ; j < len(data) && float64(data[j]) < cut; j++ {
+			count++
+		}
+
+		prevCutIdx = j
+		buckets[i] = count
+
+		if count > maxBucket {
+			maxBucket = count
+		}
+	}
+
+	// Scale the graph to a reasonable maximum height
+	heightRatio := float64(maxHeight) / float64(maxBucket)
+	for i := 0; i < len(buckets); i++ {
+		buckets[i] = int(math.Ceil(float64(buckets[i]) * heightRatio))
+	}
+
+	// Scan downward over the histogram printing line by line
+	hist := make([]byte, 0)
+	for i := maxHeight; i >= 0; i-- {
+		for j := 0; j < numBuckets; j++ {
+			if i == 0 {
+				hist = append(hist, byte('-'))
+			} else if buckets[j] == i {
+				hist = append(hist, byte('|'))
+				buckets[j]--
+			} else {
+				hist = append(hist, byte(' '))
+			}
+		}
+
+		hist = append(hist, byte('\n'))
+	}
+
+	_, err := fmt.Print(string(hist))
+	return err
+}

--- a/client/textprot/prot.go
+++ b/client/textprot/prot.go
@@ -1,74 +1,42 @@
-/**
- * Copyright 2015 Netflix, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package textprot
 
+import "bufio"
 import "fmt"
-import "io"
 import "strings"
 
 import "../common"
 
 const VERBOSE = false
 
-// reads a line without needing to use a bufio.Reader
-func rl(r io.Reader) (string, error) {
-	retval := make([]byte, 1024)
-	b := make([]byte, 1)
-	cur := 0
-
-	for b[0] != '\n' {
-		n, err := r.Read(b)
-		if err != nil {
-			return "", err
-		}
-		if n < 1 {
-			continue
-		}
-
-		retval[cur] = b[0]
-		cur++
-
-		if cur >= cap(retval) {
-			newretval := make([]byte, 2*len(retval))
-			copy(newretval, retval)
-			retval = newretval
-		}
-	}
-
-	return string(retval[:cur]), nil
-}
-
 type TextProt struct{}
 
-func (t TextProt) Set(rw io.ReadWriter, key []byte, value []byte) error {
+func (t TextProt) Set(rw *bufio.ReadWriter, key []byte, value []byte) error {
 	strKey := string(key)
 	if VERBOSE {
 		fmt.Printf("Setting key %s to value of length %v\n", strKey, len(value))
 	}
 
-	_, err := fmt.Fprintf(rw, "set %s 0 0 %v\r\n", strKey, len(value))
-	if err != nil {
-		return err
-	}
-	_, err = fmt.Fprintf(rw, "%s\r\n", string(value))
-	if err != nil {
+	if _, err := fmt.Fprintf(rw, "set %s 0 0 %v\r\n%s\r\n", strKey, len(value), string(value)); err != nil {
 		return err
 	}
 
-	response, err := rl(rw)
+	rw.Flush()
+
+	response, err := rw.ReadString('\n')
 	if err != nil {
 		return err
 	}
@@ -81,19 +49,20 @@ func (t TextProt) Set(rw io.ReadWriter, key []byte, value []byte) error {
 	return nil
 }
 
-func (t TextProt) Get(rw io.ReadWriter, key []byte) error {
+func (t TextProt) Get(rw *bufio.ReadWriter, key []byte) error {
 	strKey := string(key)
 	if VERBOSE {
 		fmt.Printf("Getting key %s\n", strKey)
 	}
 
-	_, err := fmt.Fprintf(rw, "get %s\r\n", strKey)
-	if err != nil {
+	if _, err := fmt.Fprintf(rw, "get %s\r\n", strKey); err != nil {
 		return err
 	}
 
+	rw.Flush()
+
 	// read the header line
-	response, err := rl(rw)
+	response, err := rw.ReadString('\n')
 	if err != nil {
 		return err
 	}
@@ -109,7 +78,7 @@ func (t TextProt) Get(rw io.ReadWriter, key []byte) error {
 	}
 
 	// then read the value
-	response, err = rl(rw)
+	response, err = rw.ReadString('\n')
 	if err != nil {
 		return err
 	}
@@ -118,7 +87,7 @@ func (t TextProt) Get(rw io.ReadWriter, key []byte) error {
 	}
 
 	// then read the END
-	response, err = rl(rw)
+	response, err = rw.ReadString('\n')
 	if err != nil {
 		return err
 	}
@@ -129,7 +98,7 @@ func (t TextProt) Get(rw io.ReadWriter, key []byte) error {
 	return nil
 }
 
-func (t TextProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
+func (t TextProt) BatchGet(rw *bufio.ReadWriter, keys [][]byte) error {
 	if VERBOSE {
 		fmt.Printf("Getting keys %v\n", keys)
 	}
@@ -145,14 +114,15 @@ func (t TextProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
 
 	cmd = append(cmd, end...)
 
-	_, err := fmt.Fprint(rw, string(cmd))
-	if err != nil {
+	if _, err := fmt.Fprint(rw, string(cmd)); err != nil {
 		return err
 	}
 
+	rw.Flush()
+
 	for {
 		// read the header line
-		response, err := rl(rw)
+		response, err := rw.ReadString('\n')
 		if err != nil {
 			return err
 		}
@@ -168,31 +138,35 @@ func (t TextProt) BatchGet(rw io.ReadWriter, keys [][]byte) error {
 		}
 
 		// then read the value
-		response, err = rl(rw)
+		response, err = rw.ReadString('\n')
 		if err != nil {
 			return err
+		}
+		if VERBOSE {
+			fmt.Println(response)
 		}
 	}
 }
 
-func (t TextProt) GAT(rw io.ReadWriter, key []byte) error {
+func (t TextProt) GAT(rw *bufio.ReadWriter, key []byte) error {
 	// Yes, the abstraction is a little bit leaky, but the code
 	// in other places benefits from the consistency.
 	panic("GAT in text protocol")
 }
 
-func (t TextProt) Delete(rw io.ReadWriter, key []byte) error {
+func (t TextProt) Delete(rw *bufio.ReadWriter, key []byte) error {
 	strKey := string(key)
 	if VERBOSE {
 		fmt.Printf("Deleting key %s\n", strKey)
 	}
 
-	_, err := fmt.Fprintf(rw, "delete %s\r\n", strKey)
-	if err != nil {
+	if _, err := fmt.Fprintf(rw, "delete %s\r\n", strKey); err != nil {
 		return err
 	}
 
-	response, err := rl(rw)
+	rw.Flush()
+
+	response, err := rw.ReadString('\n')
 	if err != nil {
 		return err
 	}
@@ -203,18 +177,19 @@ func (t TextProt) Delete(rw io.ReadWriter, key []byte) error {
 	return nil
 }
 
-func (t TextProt) Touch(rw io.ReadWriter, key []byte) error {
+func (t TextProt) Touch(rw *bufio.ReadWriter, key []byte) error {
 	strKey := string(key)
 	if VERBOSE {
 		fmt.Printf("Touching key %s\n", strKey)
 	}
 
-	_, err := fmt.Fprintf(rw, "touch %s %v\r\n", strKey, common.Exp())
-	if err != nil {
+	if _, err := fmt.Fprintf(rw, "touch %s %v\r\n", strKey, common.Exp()); err != nil {
 		return err
 	}
 
-	response, err := rl(rw)
+	rw.Flush()
+
+	response, err := rw.ReadString('\n')
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Added a bunch of improvements after instrumenting the blast script.

* -pprof flag to profile the testing application
* Moved back to bufio
* Got rid of lock contention by using separate rand instances
* Print fancy histograms per-command after testing complete