### PR TITLE
WIP - Counters

### DIFF
--- a/binprot/commands.go
+++ b/binprot/commands.go
@@ -14,8 +14,13 @@
 
 package binprot
 
-import "io"
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"io"
+
+	"github.com/netflix/rend/common"
+	"github.com/netflix/rend/metrics"
+)
 
 func WriteSetCmd(w io.Writer, key []byte, flags, exptime, dataSize uint32) error {
 	// opcode, keyLength, extraLength, totalBodyLength
@@ -30,7 +35,11 @@ func WriteSetCmd(w io.Writer, key []byte, flags, exptime, dataSize uint32) error
 	binary.Write(w, binary.BigEndian, header)
 	binary.Write(w, binary.BigEndian, flags)
 	binary.Write(w, binary.BigEndian, exptime)
-	return binary.Write(w, binary.BigEndian, key)
+	err := binary.Write(w, binary.BigEndian, key)
+
+	metrics.IncCounterBy(common.MetricBytesWrittenLocal, uint64(ReqHeaderLen+totalBodyLength))
+
+	return err
 }
 
 func WriteGetCmd(w io.Writer, key []byte) error {
@@ -40,7 +49,11 @@ func WriteGetCmd(w io.Writer, key []byte) error {
 	//fmt.Printf("Get: key: %v | totalBodyLength: %v\n", string(key), len(key))
 
 	binary.Write(w, binary.BigEndian, header)
-	return binary.Write(w, binary.BigEndian, key)
+	err := binary.Write(w, binary.BigEndian, key)
+
+	metrics.IncCounterBy(common.MetricBytesWrittenLocal, uint64(ReqHeaderLen+len(key)))
+
+	return err
 }
 
 func WriteGetQCmd(w io.Writer, key []byte) error {
@@ -50,7 +63,11 @@ func WriteGetQCmd(w io.Writer, key []byte) error {
 	//fmt.Printf("GetQ: key: %v | totalBodyLength: %v\n", string(key), len(key))
 
 	binary.Write(w, binary.BigEndian, header)
-	return binary.Write(w, binary.BigEndian, key)
+	err := binary.Write(w, binary.BigEndian, key)
+
+	metrics.IncCounterBy(common.MetricBytesWrittenLocal, uint64(ReqHeaderLen+len(key)))
+
+	return err
 }
 
 func WriteGATCmd(w io.Writer, key []byte, exptime uint32) error {
@@ -64,7 +81,11 @@ func WriteGATCmd(w io.Writer, key []byte, exptime uint32) error {
 
 	binary.Write(w, binary.BigEndian, header)
 	binary.Write(w, binary.BigEndian, exptime)
-	return binary.Write(w, binary.BigEndian, key)
+	err := binary.Write(w, binary.BigEndian, key)
+
+	metrics.IncCounterBy(common.MetricBytesWrittenLocal, uint64(ReqHeaderLen+totalBodyLength))
+
+	return err
 }
 
 func WriteGATQCmd(w io.Writer, key []byte, exptime uint32) error {
@@ -78,7 +99,11 @@ func WriteGATQCmd(w io.Writer, key []byte, exptime uint32) error {
 
 	binary.Write(w, binary.BigEndian, header)
 	binary.Write(w, binary.BigEndian, exptime)
-	return binary.Write(w, binary.BigEndian, key)
+	err := binary.Write(w, binary.BigEndian, key)
+
+	metrics.IncCounterBy(common.MetricBytesWrittenLocal, uint64(ReqHeaderLen+totalBodyLength))
+
+	return err
 }
 
 func WriteDeleteCmd(w io.Writer, key []byte) error {
@@ -88,7 +113,11 @@ func WriteDeleteCmd(w io.Writer, key []byte) error {
 	//fmt.Printf("Delete: key: %v | totalBodyLength: %v\n", string(key), len(key))
 
 	binary.Write(w, binary.BigEndian, header)
-	return binary.Write(w, binary.BigEndian, key)
+	err := binary.Write(w, binary.BigEndian, key)
+
+	metrics.IncCounterBy(common.MetricBytesWrittenLocal, uint64(ReqHeaderLen+len(key)))
+
+	return err
 }
 
 func WriteTouchCmd(w io.Writer, key []byte, exptime uint32) error {
@@ -103,12 +132,21 @@ func WriteTouchCmd(w io.Writer, key []byte, exptime uint32) error {
 
 	binary.Write(w, binary.BigEndian, header)
 	binary.Write(w, binary.BigEndian, exptime)
-	return binary.Write(w, binary.BigEndian, key)
+	err := binary.Write(w, binary.BigEndian, key)
+
+	metrics.IncCounterBy(common.MetricBytesWrittenLocal, uint64(ReqHeaderLen+totalBodyLength))
+
+	return err
 }
 
 func WriteNoopCmd(w io.Writer) error {
 	// opcode, keyLength, extraLength, totalBodyLength
 	header := MakeRequestHeader(OpcodeNoop, 0, 0, 0)
 	//fmt.Printf("Delete: key: %v | totalBodyLength: %v\n", string(key), len(key))
-	return binary.Write(w, binary.BigEndian, header)
+
+	err := binary.Write(w, binary.BigEndian, header)
+
+	metrics.IncCounterBy(common.MetricBytesWrittenLocal, uint64(ReqHeaderLen))
+
+	return err
 }

--- a/binprot/parser.go
+++ b/binprot/parser.go
@@ -123,8 +123,7 @@ func NewBinaryParser(reader *bufio.Reader) BinaryParser {
 
 func (b BinaryParser) Parse() (interface{}, common.RequestType, error) {
 	// read in the full header before any variable length fields
-	var reqHeader RequestHeader
-	err := binary.Read(b.reader, binary.BigEndian, &reqHeader)
+	reqHeader, err := ReadRequestHeader(b.reader)
 
 	if err != nil {
 		return nil, common.RequestUnknown, err

--- a/binprot/types.go
+++ b/binprot/types.go
@@ -15,7 +15,6 @@
 package binprot
 
 import (
-	"bytes"
 	"encoding/binary"
 	"errors"
 	"io"
@@ -177,14 +176,11 @@ func MakeRequestHeader(opcode, keyLength, extraLength, totalBodyLength int) Requ
 }
 
 func ReadRequestHeader(reader io.Reader) (RequestHeader, error) {
-	// read in the full header before any variable length fields
-	headerBuf := make([]byte, ReqHeaderLen)
-	if _, err := io.ReadFull(reader, headerBuf); err != nil {
+	var reqHeader RequestHeader
+	if err := binary.Read(reader, binary.BigEndian, &reqHeader); err != nil {
 		return RequestHeader{}, err
 	}
 
-	var reqHeader RequestHeader
-	binary.Read(bytes.NewBuffer(headerBuf), binary.BigEndian, &reqHeader)
 	metrics.IncCounterBy(common.MetricBytesReadRemote, ReqHeaderLen)
 
 	if reqHeader.Magic != MagicRequest {
@@ -209,14 +205,10 @@ type ResponseHeader struct {
 }
 
 func ReadResponseHeader(reader io.Reader) (ResponseHeader, error) {
-	// read in the full header before any variable length fields
-	headerBuf := make([]byte, resHeaderLen)
-	if _, err := io.ReadFull(reader, headerBuf); err != nil {
+	var resHeader ResponseHeader
+	if err := binary.Read(reader, binary.BigEndian, &resHeader); err != nil {
 		return ResponseHeader{}, err
 	}
-
-	var resHeader ResponseHeader
-	binary.Read(bytes.NewBuffer(headerBuf), binary.BigEndian, &resHeader)
 
 	metrics.IncCounterBy(common.MetricBytesReadLocal, resHeaderLen)
 

--- a/binprot/types.go
+++ b/binprot/types.go
@@ -185,7 +185,7 @@ func ReadRequestHeader(reader io.Reader) (RequestHeader, error) {
 	var reqHeader RequestHeader
 	binary.Read(bytes.NewBuffer(headerBuf), binary.BigEndian, &reqHeader)
 
-	if reqHeader.Magic != MagicResponse {
+	if reqHeader.Magic != MagicRequest {
 		return RequestHeader{}, ErrBadMagic
 	}
 

--- a/binprot/types.go
+++ b/binprot/types.go
@@ -21,6 +21,7 @@ import (
 	"io"
 
 	"github.com/netflix/rend/common"
+	"github.com/netflix/rend/metrics"
 )
 
 var ErrBadMagic = errors.New("Bad magic value")
@@ -184,6 +185,7 @@ func ReadRequestHeader(reader io.Reader) (RequestHeader, error) {
 
 	var reqHeader RequestHeader
 	binary.Read(bytes.NewBuffer(headerBuf), binary.BigEndian, &reqHeader)
+	metrics.IncCounterBy(common.MetricBytesReadRemote, ReqHeaderLen)
 
 	if reqHeader.Magic != MagicRequest {
 		return RequestHeader{}, ErrBadMagic
@@ -243,6 +245,8 @@ func ReadResponseHeader(reader io.Reader) (ResponseHeader, error) {
 
 	var resHeader ResponseHeader
 	binary.Read(bytes.NewBuffer(headerBuf), binary.BigEndian, &resHeader)
+
+	metrics.IncCounterBy(common.MetricBytesReadLocal, resHeaderLen)
 
 	if resHeader.Magic != MagicResponse {
 		return ResponseHeader{}, ErrBadMagic

--- a/binprot/types.go
+++ b/binprot/types.go
@@ -208,34 +208,6 @@ type ResponseHeader struct {
 	CASToken        uint64
 }
 
-func makeSuccessResponseHeader(opcode, keyLength, extraLength, totalBodyLength, opaqueToken int) ResponseHeader {
-	return ResponseHeader{
-		Magic:           MagicResponse,
-		Opcode:          uint8(opcode),
-		KeyLength:       uint16(keyLength),
-		ExtraLength:     uint8(extraLength),
-		DataType:        uint8(0),
-		Status:          uint16(StatusSuccess),
-		TotalBodyLength: uint32(totalBodyLength),
-		OpaqueToken:     uint32(opaqueToken),
-		CASToken:        uint64(0),
-	}
-}
-
-func makeErrorResponseHeader(opcode, status, opaqueToken int) ResponseHeader {
-	return ResponseHeader{
-		Magic:           MagicResponse,
-		Opcode:          uint8(opcode),
-		KeyLength:       uint16(0),
-		ExtraLength:     uint8(0),
-		DataType:        uint8(0),
-		Status:          uint16(status),
-		TotalBodyLength: uint32(0),
-		OpaqueToken:     uint32(opaqueToken),
-		CASToken:        uint64(0),
-	}
-}
-
 func ReadResponseHeader(reader io.Reader) (ResponseHeader, error) {
 	// read in the full header before any variable length fields
 	headerBuf := make([]byte, resHeaderLen)

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -14,8 +14,36 @@
 
 package common
 
-import "errors"
+import (
+	"errors"
 
+	"github.com/netflix/rend/metrics"
+)
+
+// Common metrics used across packages
+const (
+	MetricBytesReadRemote     = "bytes_read_remote"
+	MetricBytesReadLocal      = "bytes_read_local"
+	MetricBytesReadLocalL1    = "bytes_read_local_l1"
+	MetricBytesReadLocalL2    = "bytes_read_local_l2"
+	MetricBytesWrittenRemote  = "bytes_written_remote"
+	MetricBytesWrittenLocal   = "bytes_written_local"
+	MetricBytesWrittenLocalL1 = "bytes_written_local_l1"
+	MetricBytesWrittenLocalL2 = "bytes_written_local_l2"
+)
+
+func init() {
+	metrics.AddCounter(MetricBytesReadRemote)
+	metrics.AddCounter(MetricBytesReadLocal)
+	metrics.AddCounter(MetricBytesReadLocalL1)
+	metrics.AddCounter(MetricBytesReadLocalL2)
+	metrics.AddCounter(MetricBytesWrittenRemote)
+	metrics.AddCounter(MetricBytesWrittenLocal)
+	metrics.AddCounter(MetricBytesWrittenLocalL1)
+	metrics.AddCounter(MetricBytesWrittenLocalL2)
+}
+
+// Errors used across the application
 var (
 	ErrBadRequest = errors.New("CLIENT_ERROR bad request")
 	ErrBadLength  = errors.New("CLIENT_ERROR length is not a valid integer")
@@ -49,9 +77,14 @@ func IsAppError(err error) bool {
 		err == ErrBadIncDecValue ||
 		err == ErrAuth ||
 		err == ErrUnknownCmd ||
-		err == ErrNoMem
+		err == ErrNoMem ||
+		err == ErrNotSupported ||
+		err == ErrInternal ||
+		err == ErrBusy ||
+		err == ErrTempFailure
 }
 
+// Request types for all protocols
 type RequestType int
 
 const (

--- a/memproxy.go
+++ b/memproxy.go
@@ -30,6 +30,7 @@ import (
 	"github.com/netflix/rend/common"
 	"github.com/netflix/rend/handlers"
 	"github.com/netflix/rend/handlers/memcached"
+	"github.com/netflix/rend/metrics"
 	"github.com/netflix/rend/textprot"
 )
 
@@ -44,11 +45,153 @@ func init() {
 	}()
 }
 
-// Set up profiling endpoint
+// Set up http debug and metrics endpoint
 func init() {
 	go http.ListenAndServe("localhost:11299", nil)
 }
 
+// Set up the counters used in this file
+const (
+	MetricConnectionsEstablishedExt = "conn_established_ext"
+	MetricConnectionsEstablishedL1  = "conn_established_l1"
+	MetricConnectionsEstablishedL2  = "conn_established_l2"
+	MetricCmdGet                    = "cmd_get"
+	MetricCmdGetL1                  = "cmd_get_l1"
+	MetricCmdGetL2                  = "cmd_get_l2"
+	MetricCmdGetHits                = "cmd_get_hits"
+	MetricCmdGetHitsL1              = "cmd_get_hits_l1"
+	MetricCmdGetHitsL2              = "cmd_get_hits_l2"
+	MetricCmdGetMisses              = "cmd_get_misses"
+	MetricCmdGetMissesL1            = "cmd_get_misses_l1"
+	MetricCmdGetMissesL2            = "cmd_get_misses_l2"
+	MetricCmdGetErrors              = "cmd_get_errors"
+	MetricCmdGetErrorsL1            = "cmd_get_errors_l1"
+	MetricCmdGetErrorsL2            = "cmd_get_errors_l2"
+	MetricCmdGetKeys                = "cmd_get_keys"
+	MetricCmdGetKeysL1              = "cmd_get_keys_l1"
+	MetricCmdGetKeysL2              = "cmd_get_keys_l2"
+	MetricCmdSet                    = "cmd_set"
+	MetricCmdSetL1                  = "cmd_set_l1"
+	MetricCmdSetL2                  = "cmd_set_l2"
+	MetricCmdSetSuccess             = "cmd_set_success"
+	MetricCmdSetSuccessL1           = "cmd_set_success_l1"
+	MetricCmdSetSuccessL2           = "cmd_set_success_l2"
+	MetricCmdSetErrors              = "cmd_set_errors"
+	MetricCmdSetErrorsL1            = "cmd_set_errors_l1"
+	MetricCmdSetErrorsL2            = "cmd_set_errors_l2"
+	MetricCmdDelete                 = "cmd_delete"
+	MetricCmdDeleteL1               = "cmd_delete_l1"
+	MetricCmdDeleteL2               = "cmd_delete_l2"
+	MetricCmdDeleteHits             = "cmd_delete_hits"
+	MetricCmdDeleteHitsL1           = "cmd_delete_hits_l1"
+	MetricCmdDeleteHitsL2           = "cmd_delete_hits_l2"
+	MetricCmdDeleteMisses           = "cmd_delete_misses"
+	MetricCmdDeleteMissesL1         = "cmd_delete_misses_l1"
+	MetricCmdDeleteMissesL2         = "cmd_delete_misses_l2"
+	MetricCmdDeleteErrors           = "cmd_delete_errors"
+	MetricCmdDeleteErrorsL1         = "cmd_delete_errors_l1"
+	MetricCmdDeleteErrorsL2         = "cmd_delete_errors_l2"
+	MetricCmdTouch                  = "cmd_touch"
+	MetricCmdTouchL1                = "cmd_touch_l1"
+	MetricCmdTouchL2                = "cmd_touch_l2"
+	MetricCmdTouchHits              = "cmd_touch_hits"
+	MetricCmdTouchHitsL1            = "cmd_touch_hits_l1"
+	MetricCmdTouchHitsL2            = "cmd_touch_hits_l2"
+	MetricCmdTouchMisses            = "cmd_touch_misses"
+	MetricCmdTouchMissesL1          = "cmd_touch_misses_l1"
+	MetricCmdTouchMissesL2          = "cmd_touch_misses_l2"
+	MetricCmdTouchErrors            = "cmd_touch_errors"
+	MetricCmdTouchErrorsL1          = "cmd_touch_errors_l1"
+	MetricCmdTouchErrorsL2          = "cmd_touch_errors_l2"
+	MetricCmdGat                    = "cmd_gat"
+	MetricCmdGatL1                  = "cmd_gat_l1"
+	MetricCmdGatL2                  = "cmd_gat_l2"
+	MetricCmdGatHits                = "cmd_gat_hits"
+	MetricCmdGatHitsL1              = "cmd_gat_hits_l1"
+	MetricCmdGatHitsL2              = "cmd_gat_hits_l2"
+	MetricCmdGatMisses              = "cmd_gat_misses"
+	MetricCmdGatMissesL1            = "cmd_gat_misses_l1"
+	MetricCmdGatMissesL2            = "cmd_gat_misses_l2"
+	MetricCmdGatErrors              = "cmd_gat_errors"
+	MetricCmdGatErrorsL1            = "cmd_gat_errors_l1"
+	MetricCmdGatErrorsL2            = "cmd_gat_errors_l2"
+	MetricCmdUnknown                = "cmd_unknown"
+	MetricErrAppError               = "err_app_err"
+	MetricErrUnrecoverable          = "err_unrecoverable"
+
+	// TODO: inconsistency metrics for when L1 is not a subset of L2
+)
+
+func init() {
+	metrics.AddCounter(MetricConnectionsEstablishedExt)
+	metrics.AddCounter(MetricConnectionsEstablishedL1)
+	metrics.AddCounter(MetricConnectionsEstablishedL2)
+	metrics.AddCounter(MetricCmdGet)
+	metrics.AddCounter(MetricCmdGetL1)
+	metrics.AddCounter(MetricCmdGetL2)
+	metrics.AddCounter(MetricCmdGetHits)
+	metrics.AddCounter(MetricCmdGetHitsL1)
+	metrics.AddCounter(MetricCmdGetHitsL2)
+	metrics.AddCounter(MetricCmdGetMisses)
+	metrics.AddCounter(MetricCmdGetMissesL1)
+	metrics.AddCounter(MetricCmdGetMissesL2)
+	metrics.AddCounter(MetricCmdGetErrors)
+	metrics.AddCounter(MetricCmdGetErrorsL1)
+	metrics.AddCounter(MetricCmdGetErrorsL2)
+	metrics.AddCounter(MetricCmdGetKeys)
+	metrics.AddCounter(MetricCmdGetKeysL1)
+	metrics.AddCounter(MetricCmdGetKeysL2)
+	metrics.AddCounter(MetricCmdSet)
+	metrics.AddCounter(MetricCmdSetL1)
+	metrics.AddCounter(MetricCmdSetL2)
+	metrics.AddCounter(MetricCmdSetSuccess)
+	metrics.AddCounter(MetricCmdSetSuccessL1)
+	metrics.AddCounter(MetricCmdSetSuccessL2)
+	metrics.AddCounter(MetricCmdSetErrors)
+	metrics.AddCounter(MetricCmdSetErrorsL1)
+	metrics.AddCounter(MetricCmdSetErrorsL2)
+	metrics.AddCounter(MetricCmdDelete)
+	metrics.AddCounter(MetricCmdDeleteL1)
+	metrics.AddCounter(MetricCmdDeleteL2)
+	metrics.AddCounter(MetricCmdDeleteHits)
+	metrics.AddCounter(MetricCmdDeleteHitsL1)
+	metrics.AddCounter(MetricCmdDeleteHitsL2)
+	metrics.AddCounter(MetricCmdDeleteMisses)
+	metrics.AddCounter(MetricCmdDeleteMissesL1)
+	metrics.AddCounter(MetricCmdDeleteMissesL2)
+	metrics.AddCounter(MetricCmdDeleteErrors)
+	metrics.AddCounter(MetricCmdDeleteErrorsL1)
+	metrics.AddCounter(MetricCmdDeleteErrorsL2)
+	metrics.AddCounter(MetricCmdTouch)
+	metrics.AddCounter(MetricCmdTouchL1)
+	metrics.AddCounter(MetricCmdTouchL2)
+	metrics.AddCounter(MetricCmdTouchHits)
+	metrics.AddCounter(MetricCmdTouchHitsL1)
+	metrics.AddCounter(MetricCmdTouchHitsL2)
+	metrics.AddCounter(MetricCmdTouchMisses)
+	metrics.AddCounter(MetricCmdTouchMissesL1)
+	metrics.AddCounter(MetricCmdTouchMissesL2)
+	metrics.AddCounter(MetricCmdTouchErrors)
+	metrics.AddCounter(MetricCmdTouchErrorsL1)
+	metrics.AddCounter(MetricCmdTouchErrorsL2)
+	metrics.AddCounter(MetricCmdGat)
+	metrics.AddCounter(MetricCmdGatL1)
+	metrics.AddCounter(MetricCmdGatL2)
+	metrics.AddCounter(MetricCmdGatHits)
+	metrics.AddCounter(MetricCmdGatHitsL1)
+	metrics.AddCounter(MetricCmdGatHitsL2)
+	metrics.AddCounter(MetricCmdGatMisses)
+	metrics.AddCounter(MetricCmdGatMissesL1)
+	metrics.AddCounter(MetricCmdGatMissesL2)
+	metrics.AddCounter(MetricCmdGatErrors)
+	metrics.AddCounter(MetricCmdGatErrorsL1)
+	metrics.AddCounter(MetricCmdGatErrorsL2)
+	metrics.AddCounter(MetricCmdUnknown)
+	metrics.AddCounter(MetricErrAppError)
+	metrics.AddCounter(MetricErrUnrecoverable)
+}
+
+// And away we go
 func main() {
 	server, err := net.Listen("tcp", ":11211")
 
@@ -66,6 +209,8 @@ func main() {
 			continue
 		}
 
+		metrics.IncCounter(MetricConnectionsEstablishedExt)
+
 		l1conn, err := net.Dial("unix", "/tmp/memcached.sock")
 
 		if err != nil {
@@ -76,6 +221,8 @@ func main() {
 			remote.Close()
 			continue
 		}
+
+		metrics.IncCounter(MetricConnectionsEstablishedL1)
 
 		l1 := memcached.NewChunkedHandler(l1conn)
 		//l1 := memcached.NewHandler(l1conn)
@@ -171,42 +318,101 @@ func handleConnectionReal(remoteConn net.Conn, l1, l2 handlers.Handler) {
 		// TODO: handle nil
 		switch reqType {
 		case common.RequestSet:
+			metrics.IncCounter(MetricCmdSet)
 			req := request.(common.SetRequest)
 			//fmt.Println("set", string(req.Key))
+
+			metrics.IncCounter(MetricCmdSetL1)
 			err = l1.Set(req, remoteReader)
 
 			if err == nil {
+				metrics.IncCounter(MetricCmdSetSuccessL1)
+				// TODO: Account for L2
+				metrics.IncCounter(MetricCmdSetSuccess)
+
 				responder.Set()
+
+			} else {
+				metrics.IncCounter(MetricCmdSetErrorsL1)
+				// TODO: Account for L2
+				metrics.IncCounter(MetricCmdSetErrors)
 			}
 
+			// TODO: L2 metrics for sets, set success, set errors
+
 		case common.RequestDelete:
+			metrics.IncCounter(MetricCmdDelete)
 			req := request.(common.DeleteRequest)
 			//fmt.Println("delete", string(req.Key))
+
+			metrics.IncCounter(MetricCmdDeleteL1)
 			err = l1.Delete(req)
 
 			if err == nil {
+				metrics.IncCounter(MetricCmdDeleteHits)
+				metrics.IncCounter(MetricCmdDeleteHitsL1)
+
 				responder.Delete()
+
+			} else if err == common.ErrKeyNotFound {
+				metrics.IncCounter(MetricCmdDeleteMissesL1)
+				// TODO: Account for L2
+				metrics.IncCounter(MetricCmdDeleteMisses)
+			} else {
+				metrics.IncCounter(MetricCmdDeleteErrorsL1)
+				// TODO: Account for L2
+				metrics.IncCounter(MetricCmdDeleteErrors)
 			}
 
+			// TODO: L2 metrics for deletes, delete hits, delete misses, delete errors
+
 		case common.RequestTouch:
+			metrics.IncCounter(MetricCmdTouch)
 			req := request.(common.TouchRequest)
 			//fmt.Println("touch", string(req.Key))
+
+			metrics.IncCounter(MetricCmdTouchL1)
 			err = l1.Touch(req)
 
 			if err == nil {
+				metrics.IncCounter(MetricCmdTouchHitsL1)
+				// TODO: Account for L2
+				metrics.IncCounter(MetricCmdTouchHits)
+
 				responder.Touch()
+
+			} else if err == common.ErrKeyNotFound {
+				metrics.IncCounter(MetricCmdTouchMissesL1)
+				// TODO: Account for L2
+				metrics.IncCounter(MetricCmdTouchMisses)
+			} else {
+				metrics.IncCounter(MetricCmdTouchMissesL1)
+				// TODO: Account for L2
+				metrics.IncCounter(MetricCmdTouchMisses)
 			}
 
+			// TODO: L2 metrics for touches, touch hits, touch misses, touch errors
+
 		case common.RequestGet:
+			metrics.IncCounter(MetricCmdGet)
 			req := request.(common.GetRequest)
+			metrics.IncCounterBy(MetricCmdGetKeys, uint64(len(req.Keys)))
 			//debugString := "get"
 			//for _, k := range req.Keys {
 			//	debugString += " "
 			//	debugString += string(k)
 			//}
 			//println(debugString)
+
+			metrics.IncCounter(MetricCmdGetL1)
+			metrics.IncCounterBy(MetricCmdGetKeysL1, uint64(len(req.Keys)))
 			resChan, errChan := l1.Get(req)
 
+			// Read all the responses back from L1.
+			// The contract is that the resChan will have GetResponse's for get hits and misses,
+			// and the errChan will have any other errors, such as an out of memory error from
+			// memcached. If any receive happens from errChan, there will be no more responses
+			// from resChan.
 			for {
 				select {
 				case res, ok := <-resChan:
@@ -214,8 +420,13 @@ func handleConnectionReal(remoteConn net.Conn, l1, l2 handlers.Handler) {
 						resChan = nil
 					} else {
 						if res.Miss {
+							metrics.IncCounter(MetricCmdGetHits)
+							metrics.IncCounter(MetricCmdGetHitsL1)
 							responder.GetMiss(res)
 						} else {
+							metrics.IncCounter(MetricCmdGetMissesL1)
+							// TODO: Account for L2
+							metrics.IncCounter(MetricCmdGetMisses)
 							responder.Get(res)
 						}
 					}
@@ -224,6 +435,8 @@ func handleConnectionReal(remoteConn net.Conn, l1, l2 handlers.Handler) {
 					if !ok {
 						errChan = nil
 					} else {
+						metrics.IncCounter(MetricCmdGetErrors)
+						metrics.IncCounter(MetricCmdGetErrorsL1)
 						err = getErr
 					}
 				}
@@ -237,29 +450,47 @@ func handleConnectionReal(remoteConn net.Conn, l1, l2 handlers.Handler) {
 				responder.GetEnd(req.NoopEnd)
 			}
 
+			// TODO: L2 metrics for gets, get hits, get misses, get errors
+
 		case common.RequestGat:
+			metrics.IncCounter(MetricCmdGat)
 			req := request.(common.GATRequest)
 			//fmt.Println("gat", string(req.Key))
+
+			metrics.IncCounter(MetricCmdGatL1)
 			res, err := l1.GAT(req)
 
 			if err == nil {
 				if res.Miss {
+					metrics.IncCounter(MetricCmdGatMissesL1)
+					// TODO: Account for L2
+					metrics.IncCounter(MetricCmdGatMisses)
 					responder.GATMiss(res)
 				} else {
+					metrics.IncCounter(MetricCmdGatHits)
+					metrics.IncCounter(MetricCmdGatHitsL1)
 					responder.GAT(res)
 					responder.GetEnd(false)
 				}
+			} else {
+				metrics.IncCounter(MetricCmdGatErrors)
+				metrics.IncCounter(MetricCmdGatErrorsL1)
 			}
 
+			//TODO: L2 metrics for gats, gat hits, gat misses, gat errors
+
 		case common.RequestUnknown:
+			metrics.IncCounter(MetricCmdUnknown)
 			err = common.ErrUnknownCmd
 		}
 
 		// TODO: distinguish fatal errors from non-fatal
 		if err != nil {
 			if common.IsAppError(err) {
+				metrics.IncCounter(MetricErrAppError)
 				responder.Error(err)
 			} else {
+				metrics.IncCounter(MetricErrUnrecoverable)
 				abort([]io.Closer{remoteConn, l1, l2}, err, binary)
 				return
 			}

--- a/memproxy.go
+++ b/memproxy.go
@@ -487,7 +487,9 @@ func handleConnectionReal(remoteConn net.Conn, l1, l2 handlers.Handler) {
 		// TODO: distinguish fatal errors from non-fatal
 		if err != nil {
 			if common.IsAppError(err) {
-				metrics.IncCounter(MetricErrAppError)
+				if err != common.ErrKeyNotFound {
+					metrics.IncCounter(MetricErrAppError)
+				}
 				responder.Error(err)
 			} else {
 				metrics.IncCounter(MetricErrUnrecoverable)

--- a/metrics/counters.go
+++ b/metrics/counters.go
@@ -1,0 +1,52 @@
+package metrics
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+var (
+	counters = make(map[string]*uint64)
+	lock     = new(sync.RWMutex)
+)
+
+func AddCounter(name string) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	temp := new(uint64)
+	atomic.StoreUint64(temp, 0)
+	counters[name] = temp
+}
+
+func IncCounter(name string) {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	atomic.AddUint64(counters[name], 1)
+}
+
+func IncCounterBy(name string, amount uint64) {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	atomic.AddUint64(counters[name], amount)
+}
+
+func GetCounter(name string) uint64 {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	return atomic.LoadUint64(counters[name])
+}
+
+func GetAllCounters() map[string]uint64 {
+	lock.RLock()
+	defer lock.RUnlock()
+
+	ret := make(map[string]uint64)
+	for name, val := range counters {
+		ret[name] = atomic.LoadUint64(val)
+	}
+	return ret
+}

--- a/metrics/counters.go
+++ b/metrics/counters.go
@@ -23,21 +23,29 @@ func IncCounter(name string) {
 	lock.RLock()
 	defer lock.RUnlock()
 
-	atomic.AddUint64(counters[name], 1)
+	if _, ok := counters[name]; ok {
+		atomic.AddUint64(counters[name], 1)
+	}
 }
 
 func IncCounterBy(name string, amount uint64) {
 	lock.RLock()
 	defer lock.RUnlock()
 
-	atomic.AddUint64(counters[name], amount)
+	if _, ok := counters[name]; ok {
+		atomic.AddUint64(counters[name], amount)
+	}
 }
 
 func GetCounter(name string) uint64 {
 	lock.RLock()
 	defer lock.RUnlock()
 
-	return atomic.LoadUint64(counters[name])
+	if _, ok := counters[name]; ok {
+		return atomic.LoadUint64(counters[name])
+	} else {
+		return uint64(0)
+	}
 }
 
 func GetAllCounters() map[string]uint64 {

--- a/metrics/endpoint.go
+++ b/metrics/endpoint.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 )
 
+const metricPrefix = "rend_"
+
 func init() {
 	http.Handle("/metrics/counters", http.HandlerFunc(printCounters))
 }
@@ -13,6 +15,6 @@ func printCounters(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	ctrs := GetAllCounters()
 	for name, val := range ctrs {
-		fmt.Fprintf(w, "%s %d\n", name, val)
+		fmt.Fprintf(w, "%s%s %d\n", metricPrefix, name, val)
 	}
 }

--- a/metrics/endpoint.go
+++ b/metrics/endpoint.go
@@ -1,0 +1,18 @@
+package metrics
+
+import (
+	"fmt"
+	"net/http"
+)
+
+func init() {
+	http.Handle("/metrics/counters", http.HandlerFunc(printCounters))
+}
+
+func printCounters(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	ctrs := GetAllCounters()
+	for name, val := range ctrs {
+		fmt.Fprintf(w, "%s %d\n", name, val)
+	}
+}


### PR DESCRIPTION
This takes care of issue #29 - Implement Counters 

The contents of this pull request is not only the counters implementation itself, but the use of them across the codebase to track everything we might need to debug an issue.

The implementation itself is fairly straightforward: A map of string key to uint64 pointer. The uint64 is operated on by the sync/atomic primitives that can atomically add a specified amount to a uint64. A sync.RWMutex is used to ensure no concurrent map alterations with the reads, but all reads are allowed concurrently. The atomic functions allow counters to be very quick - they take a negligible amount of time in the runtime of the program even under load.

Counters include the number of all operations and the high-level results of all those operations, the number of bytes read and written from and to both the remote connection and the local one(s), and detailed counts of the number of keys, chunks, and other items that are touched while fulfilling a request. It also tracks the number of active connections.