### PR TITLE
Add command

### DIFF
--- a/binprot/commands.go
+++ b/binprot/commands.go
@@ -42,6 +42,26 @@ func WriteSetCmd(w io.Writer, key []byte, flags, exptime, dataSize uint32) error
 	return err
 }
 
+func WriteAddCmd(w io.Writer, key []byte, flags, exptime, dataSize uint32) error {
+	// opcode, keyLength, extraLength, totalBodyLength
+	// key + extras + body
+	extrasLen := 8
+	totalBodyLength := len(key) + extrasLen + int(dataSize)
+	header := MakeRequestHeader(OpcodeAdd, len(key), extrasLen, totalBodyLength)
+
+	//fmt.Printf("Add: key: %v | flags: %v | exptime: %v | dataSize: %v | totalBodyLength: %v\n",
+	//string(key), flags, exptime, dataSize, totalBodyLength)
+
+	binary.Write(w, binary.BigEndian, header)
+	binary.Write(w, binary.BigEndian, flags)
+	binary.Write(w, binary.BigEndian, exptime)
+	err := binary.Write(w, binary.BigEndian, key)
+
+	metrics.IncCounterBy(common.MetricBytesWrittenLocal, uint64(ReqHeaderLen+totalBodyLength))
+
+	return err
+}
+
 func WriteGetCmd(w io.Writer, key []byte) error {
 	// opcode, keyLength, extraLength, totalBodyLength
 	header := MakeRequestHeader(OpcodeGet, len(key), 0, len(key))

--- a/binprot/respond.go
+++ b/binprot/respond.go
@@ -114,15 +114,23 @@ func (b BinaryResponder) Set(opaque uint32) error {
 	return writeSuccessResponseHeader(b.writer, OpcodeSet, 0, 0, 0, opaque, true)
 }
 
-func (b BinaryResponder) Get(response common.GetResponse) error {
-	return getCommon(b.writer, response, OpcodeGet)
+func (b BinaryResponder) Add(opaque uint32, added bool) error {
+	if added {
+		return writeSuccessResponseHeader(b.writer, OpcodeAdd, 0, 0, 0, opaque, true)
+	} else {
+		return writeErrorResponseHeader(b.writer, OpcodeAdd, StatusKeyExists, opaque)
+	}
 }
 
-func (b BinaryResponder) GetMiss(response common.GetResponse) error {
-	if !response.Quiet {
-		return b.Error(response.Opaque, common.RequestGet, common.ErrKeyNotFound)
+func (b BinaryResponder) Get(response common.GetResponse) error {
+	if response.Miss {
+		if !response.Quiet {
+			return b.Error(response.Opaque, common.RequestGet, common.ErrKeyNotFound)
+		}
+		return nil
+	} else {
+		return getCommon(b.writer, response, OpcodeGet)
 	}
-	return nil
 }
 
 func (b BinaryResponder) GetEnd(opaque uint32, noopEnd bool) error {
@@ -136,14 +144,14 @@ func (b BinaryResponder) GetEnd(opaque uint32, noopEnd bool) error {
 }
 
 func (b BinaryResponder) GAT(response common.GetResponse) error {
-	return getCommon(b.writer, response, OpcodeGat)
-}
-
-func (b BinaryResponder) GATMiss(response common.GetResponse) error {
-	if !response.Quiet {
-		return b.Error(response.Opaque, common.RequestGat, common.ErrKeyNotFound)
+	if response.Miss {
+		if !response.Quiet {
+			return b.Error(response.Opaque, common.RequestGat, common.ErrKeyNotFound)
+		}
+		return nil
+	} else {
+		return getCommon(b.writer, response, OpcodeGat)
 	}
-	return nil
 }
 
 func (b BinaryResponder) Delete(opaque uint32) error {

--- a/binprot/types.go
+++ b/binprot/types.go
@@ -67,7 +67,7 @@ const (
 
 	StatusSuccess        = uint16(0x00)
 	StatusKeyEnoent      = uint16(0x01)
-	StatusKeyEexists     = uint16(0x02)
+	StatusKeyExists      = uint16(0x02)
 	StatusE2big          = uint16(0x03)
 	StatusEinval         = uint16(0x04)
 	StatusNotStored      = uint16(0x05)
@@ -87,7 +87,7 @@ func DecodeError(header ResponseHeader) error {
 	switch header.Status {
 	case StatusKeyEnoent:
 		return common.ErrKeyNotFound
-	case StatusKeyEexists:
+	case StatusKeyExists:
 		return common.ErrKeyExists
 	case StatusE2big:
 		return common.ErrValueTooBig
@@ -120,7 +120,7 @@ func errorToCode(err error) uint16 {
 	case common.ErrKeyNotFound:
 		return StatusKeyEnoent
 	case common.ErrKeyExists:
-		return StatusKeyEexists
+		return StatusKeyExists
 	case common.ErrValueTooBig:
 		return StatusE2big
 	case common.ErrInvalidArgs:

--- a/client/binprot/prot.go
+++ b/client/binprot/prot.go
@@ -80,6 +80,27 @@ func (b BinProt) Set(rw *bufio.ReadWriter, key, value []byte) error {
 	return consumeResponse(rw.Reader)
 }
 
+func (b BinProt) Add(rw *bufio.ReadWriter, key, value []byte) error {
+	// add packet contains the req header, flags, and expiration
+	// flags are irrelevant, and are thus zero.
+	// expiration could be important, so hammer with random values from 1 sec up to 1 hour
+
+	// Header
+	bodylen := 8 + len(key) + len(value)
+	writeReq(rw, Add, len(key), 8, bodylen)
+	// Extras
+	binary.Write(rw, binary.BigEndian, uint32(0))
+	binary.Write(rw, binary.BigEndian, common.Exp())
+	// Body / data
+	rw.Write(key)
+	rw.Write(value)
+
+	rw.Flush()
+
+	// consume all of the response and discard
+	return consumeResponse(rw.Reader)
+}
+
 func (b BinProt) Get(rw *bufio.ReadWriter, key []byte) error {
 	// Header
 	writeReq(rw, Get, len(key), 0, len(key))

--- a/client/common/types.go
+++ b/client/common/types.go
@@ -20,6 +20,7 @@ type Prot interface {
 	// Yes, the abstraction is a little bit leaky, but the code
 	// in other places benefits from the consistency.
 	Set(rw *bufio.ReadWriter, key []byte, value []byte) error
+	Add(rw *bufio.ReadWriter, key []byte, value []byte) error
 	Get(rw *bufio.ReadWriter, key []byte) error
 	GAT(rw *bufio.ReadWriter, key []byte) error
 	BatchGet(rw *bufio.ReadWriter, keys [][]byte) error
@@ -34,20 +35,19 @@ const (
 	Bget
 	Gat
 	Set
+	Add
 	Touch
 	Delete
 )
 
-var AllOps []Op
-
-func init() {
-	AllOps = []Op{Get, Bget, Gat, Set, Touch, Delete}
-}
+var AllOps = []Op{Get, Bget, Gat, Set, Add, Touch, Delete}
 
 func (o Op) String() string {
 	switch o {
 	case Set:
 		return "Set"
+	case Add:
+		return "Add"
 	case Get:
 		return "Get"
 	case Gat:

--- a/client/textprot/prot.go
+++ b/client/textprot/prot.go
@@ -49,6 +49,31 @@ func (t TextProt) Set(rw *bufio.ReadWriter, key []byte, value []byte) error {
 	return nil
 }
 
+func (t TextProt) Add(rw *bufio.ReadWriter, key []byte, value []byte) error {
+	strKey := string(key)
+	if VERBOSE {
+		fmt.Printf("Adding key %s, value of length %v\n", strKey, len(value))
+	}
+
+	if _, err := fmt.Fprintf(rw, "add %s 0 0 %v\r\n%s\r\n", strKey, len(value), string(value)); err != nil {
+		return err
+	}
+
+	rw.Flush()
+
+	response, err := rw.ReadString('\n')
+	if err != nil {
+		return err
+	}
+
+	if VERBOSE {
+		fmt.Println(response)
+		fmt.Printf("Added key %s\n", strKey)
+	}
+
+	return nil
+}
+
 func (t TextProt) Get(rw *bufio.ReadWriter, key []byte) error {
 	strKey := string(key)
 	if VERBOSE {

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -41,6 +41,7 @@ var (
 	ErrBadRequest = errors.New("CLIENT_ERROR bad request")
 	ErrBadLength  = errors.New("CLIENT_ERROR length is not a valid integer")
 	ErrBadFlags   = errors.New("CLIENT_ERROR flags is not a valid integer")
+	ErrBadExptime = errors.New("CLIENT_ERROR exptime is not a valid integer")
 
 	ErrNoError        = errors.New("Success")
 	ErrKeyNotFound    = errors.New("ERROR Key not found")
@@ -120,11 +121,10 @@ type RequestParser interface {
 // corresponding RequestParser.
 type Responder interface {
 	Set(opaque uint32) error
+	Add(opaque uint32, added bool) error
 	Get(response GetResponse) error
-	GetMiss(response GetResponse) error
 	GetEnd(opaque uint32, noopEnd bool) error
 	GAT(response GetResponse) error
-	GATMiss(response GetResponse) error
 	Delete(opaque uint32) error
 	Touch(opaque uint32) error
 	Error(opaque uint32, reqType RequestType, err error) error

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -97,6 +97,9 @@ const (
 	// depending on L1 / L2 handling.
 	RequestSet
 
+	// RequestAdd will perform the same operations as set, but only if the key does not exist
+	RequestAdd
+
 	// RequestDelete deletes a piece of data from all levels of cache
 	RequestDelete
 

--- a/handlers/memcached/chunked/handler.go
+++ b/handlers/memcached/chunked/handler.go
@@ -107,7 +107,7 @@ func (h Handler) Close() error {
 	return h.conn.Close()
 }
 
-func (h Handler) Set(cmd common.SetRequest, src *bufio.Reader) error {
+func (h Handler) Set(cmd common.SetRequest) error {
 	// Specialized chunk reader to make the code here much simpler
 	limChunkReader := newChunkLimitedReader(bytes.NewBuffer(cmd.Data), int64(chunkSize), int64(len(cmd.Data)))
 	numChunks := int(math.Ceil(float64(len(cmd.Data)) / float64(chunkSize)))

--- a/handlers/memcached/chunked/handler.go
+++ b/handlers/memcached/chunked/handler.go
@@ -235,6 +235,11 @@ func (h Handler) Set(cmd common.SetRequest) error {
 
 	return nil
 }
+func (h Handler) Add(cmd common.SetRequest) error {
+	// be fancy here and check if the metadata exists. Try to "add" it, and if the response is a "already exists" then
+	// bail and return already exists
+	return nil
+}
 
 func (h Handler) Get(cmd common.GetRequest) (<-chan common.GetResponse, <-chan error) {
 	// No buffering here so there's not multiple gets in memory

--- a/handlers/memcached/std/handler.go
+++ b/handlers/memcached/std/handler.go
@@ -82,7 +82,38 @@ func (h Handler) Set(cmd common.SetRequest) error {
 		}*/
 
 		// Discard response body
-		n, ioerr = h.rw.Discard(int(resHeader.TotalBodyLength))
+		n, ioerr := h.rw.Discard(int(resHeader.TotalBodyLength))
+		metrics.IncCounterBy(common.MetricBytesReadLocal, uint64(n))
+		if ioerr != nil {
+			return ioerr
+		}
+
+		return err
+	}
+
+	return nil
+}
+
+func (h Handler) Add(cmd common.SetRequest) error {
+	// TODO: should there be a unique flags value for regular data?
+	// Write command header
+	if err := binprot.WriteAddCmd(h.rw.Writer, cmd.Key, cmd.Flags, cmd.Exptime, uint32(len(cmd.Data))); err != nil {
+		return err
+	}
+
+	// Write value
+	h.rw.Write(cmd.Data)
+	metrics.IncCounterBy(common.MetricBytesWrittenLocal, uint64(len(cmd.Data)))
+
+	if err := h.rw.Flush(); err != nil {
+		return err
+	}
+
+	// Read server's response
+	resHeader, err := readResponseHeader(h.rw.Reader)
+	if err != nil {
+		// Discard response body
+		n, ioerr := h.rw.Discard(int(resHeader.TotalBodyLength))
 		metrics.IncCounterBy(common.MetricBytesReadLocal, uint64(n))
 		if ioerr != nil {
 			return ioerr

--- a/handlers/memcached/std/handler.go
+++ b/handlers/memcached/std/handler.go
@@ -55,7 +55,7 @@ func (h Handler) Close() error {
 	return h.conn.Close()
 }
 
-func (h Handler) Set(cmd common.SetRequest, src *bufio.Reader) error {
+func (h Handler) Set(cmd common.SetRequest) error {
 	// TODO: should there be a unique flags value for regular data?
 	// Write command header
 	if err := binprot.WriteSetCmd(h.rw.Writer, cmd.Key, cmd.Flags, cmd.Exptime, uint32(len(cmd.Data))); err != nil {
@@ -74,11 +74,12 @@ func (h Handler) Set(cmd common.SetRequest, src *bufio.Reader) error {
 	resHeader, err := readResponseHeader(h.rw.Reader)
 	if err != nil {
 		// Discard request body
+		/*/ only when using streaming sets
 		n, ioerr := src.Discard(len(cmd.Data))
 		metrics.IncCounterBy(common.MetricBytesReadRemote, uint64(n))
 		if ioerr != nil {
 			return ioerr
-		}
+		}*/
 
 		// Discard response body
 		n, ioerr = h.rw.Discard(int(resHeader.TotalBodyLength))

--- a/handlers/types.go
+++ b/handlers/types.go
@@ -14,12 +14,10 @@
 
 package handlers
 
-import "bufio"
-
 import "github.com/netflix/rend/common"
 
 type Handler interface {
-	Set(cmd common.SetRequest, src *bufio.Reader) error
+	Set(cmd common.SetRequest) error
 	Get(cmd common.GetRequest) (<-chan common.GetResponse, <-chan error)
 	GAT(cmd common.GATRequest) (common.GetResponse, error)
 	Delete(cmd common.DeleteRequest) error

--- a/handlers/types.go
+++ b/handlers/types.go
@@ -18,6 +18,7 @@ import "github.com/netflix/rend/common"
 
 type Handler interface {
 	Set(cmd common.SetRequest) error
+	Add(cmd common.SetRequest) error
 	Get(cmd common.GetRequest) (<-chan common.GetResponse, <-chan error)
 	GAT(cmd common.GATRequest) (common.GetResponse, error)
 	Delete(cmd common.DeleteRequest) error

--- a/memproxy.go
+++ b/memproxy.go
@@ -289,7 +289,7 @@ func handleConnection(remoteConn net.Conn, l1, l2 handlers.Handler) {
 			//fmt.Println("set", string(req.Key))
 
 			metrics.IncCounter(MetricCmdSetL1)
-			err = l1.Set(req, remoteReader)
+			err = l1.Set(req)
 
 			if err == nil {
 				metrics.IncCounter(MetricCmdSetSuccessL1)

--- a/memproxy.go
+++ b/memproxy.go
@@ -94,6 +94,18 @@ var (
 	MetricCmdSetErrors              = metrics.AddCounter("cmd_set_errors")
 	MetricCmdSetErrorsL1            = metrics.AddCounter("cmd_set_errors_l1")
 	MetricCmdSetErrorsL2            = metrics.AddCounter("cmd_set_errors_l2")
+	MetricCmdAdd                    = metrics.AddCounter("cmd_add")
+	MetricCmdAddL1                  = metrics.AddCounter("cmd_add_l1")
+	MetricCmdAddL2                  = metrics.AddCounter("cmd_add_l2")
+	MetricCmdAddStored              = metrics.AddCounter("cmd_add_stored")
+	MetricCmdAddStoredL1            = metrics.AddCounter("cmd_add_stored_l1")
+	MetricCmdAddStoredL2            = metrics.AddCounter("cmd_add_stored_l2")
+	MetricCmdAddNotStored           = metrics.AddCounter("cmd_add_not_stored")
+	MetricCmdAddNotStoredL1         = metrics.AddCounter("cmd_add_not_stored_l1")
+	MetricCmdAddNotStoredL2         = metrics.AddCounter("cmd_add_not_stored_l2")
+	MetricCmdAddErrors              = metrics.AddCounter("cmd_add_errors")
+	MetricCmdAddErrorsL1            = metrics.AddCounter("cmd_add_errors_l1")
+	MetricCmdAddErrorsL2            = metrics.AddCounter("cmd_add_errors_l2")
 	MetricCmdDelete                 = metrics.AddCounter("cmd_delete")
 	MetricCmdDeleteL1               = metrics.AddCounter("cmd_delete_l1")
 	MetricCmdDeleteL2               = metrics.AddCounter("cmd_delete_l2")
@@ -135,6 +147,7 @@ var (
 	MetricErrUnrecoverable          = metrics.AddCounter("err_unrecoverable")
 
 	HistSet    = metrics.AddHistogram("set")
+	HistAdd    = metrics.AddHistogram("add")
 	HistDelete = metrics.AddHistogram("delete")
 	HistTouch  = metrics.AddHistogram("touch")
 	HistGet    = metrics.AddHistogram("get")
@@ -306,6 +319,37 @@ func handleConnection(remoteConn net.Conn, l1, l2 handlers.Handler) {
 
 			// TODO: L2 metrics for sets, set success, set errors
 
+		case common.RequestAdd:
+			metrics.IncCounter(MetricCmdAdd)
+			req := request.(common.SetRequest)
+			opaque = req.Opaque
+			//fmt.Println("add", string(req.Key))
+
+			// TODO: L2 first, then L1
+
+			metrics.IncCounter(MetricCmdAddL1)
+			err = l1.Add(req)
+
+			if err == nil {
+				metrics.IncCounter(MetricCmdAddStoredL1)
+				// TODO: Account for L2
+				metrics.IncCounter(MetricCmdAddStored)
+
+				err = responder.Add(req.Opaque, true)
+
+			} else if err == common.ErrKeyExists {
+				metrics.IncCounter(MetricCmdAddNotStoredL1)
+				// TODO: Account for L2
+				metrics.IncCounter(MetricCmdAddNotStored)
+				err = responder.Add(req.Opaque, false)
+			} else {
+				metrics.IncCounter(MetricCmdAddErrorsL1)
+				// TODO: Account for L2
+				metrics.IncCounter(MetricCmdAddErrors)
+			}
+
+			// TODO: L2 metrics for adds, add stored, add not stored, add errors
+
 		case common.RequestDelete:
 			metrics.IncCounter(MetricCmdDelete)
 			req := request.(common.DeleteRequest)
@@ -394,12 +438,11 @@ func handleConnection(remoteConn net.Conn, l1, l2 handlers.Handler) {
 							metrics.IncCounter(MetricCmdGetMissesL1)
 							// TODO: Account for L2
 							metrics.IncCounter(MetricCmdGetMisses)
-							responder.GetMiss(res)
 						} else {
 							metrics.IncCounter(MetricCmdGetHits)
 							metrics.IncCounter(MetricCmdGetHitsL1)
-							responder.Get(res)
 						}
+						responder.Get(res)
 					}
 
 				case getErr, ok := <-errChan:
@@ -437,13 +480,15 @@ func handleConnection(remoteConn net.Conn, l1, l2 handlers.Handler) {
 					metrics.IncCounter(MetricCmdGatMissesL1)
 					// TODO: Account for L2
 					metrics.IncCounter(MetricCmdGatMisses)
-					responder.GATMiss(res)
 				} else {
 					metrics.IncCounter(MetricCmdGatHits)
 					metrics.IncCounter(MetricCmdGatHitsL1)
-					responder.GAT(res)
-					responder.GetEnd(0, false)
 				}
+				responder.GAT(res)
+				// There is no GetEnd call required here since this is only ever
+				// done in the binary protocol, where there's no END marker.
+				// Calling responder.GetEnd was a no-op here and is just useless.
+				//responder.GetEnd(0, false)
 			} else {
 				metrics.IncCounter(MetricCmdGatErrors)
 				metrics.IncCounter(MetricCmdGatErrorsL1)
@@ -474,6 +519,8 @@ func handleConnection(remoteConn net.Conn, l1, l2 handlers.Handler) {
 		switch reqType {
 		case common.RequestSet:
 			metrics.ObserveHist(HistSet, dur)
+		case common.RequestAdd:
+			metrics.ObserveHist(HistAdd, dur)
 		case common.RequestDelete:
 			metrics.ObserveHist(HistDelete, dur)
 		case common.RequestTouch:


### PR DESCRIPTION
Implementing add across all parts of the application. This included the text and binary protocol parsers and responders, the chunked and standard local handlers, the common package constants, and the main memproxy file. The blast client load tester also implements add now as a part of the operations it uses to test.