### PR TITLE
GetE command

### DIFF
--- a/binprot/types.go
+++ b/binprot/types.go
@@ -62,6 +62,9 @@ const (
 	OpcodeGatKQ      = uint8(0x24)
 	OpcodeInvalid    = uint8(0xFF)
 
+	OpcodeGetE  = uint8(0x40)
+	OpcodeGetEQ = uint8(0x41)
+
 	StatusSuccess        = uint16(0x00)
 	StatusKeyEnoent      = uint16(0x01)
 	StatusKeyExists      = uint16(0x02)

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -96,6 +96,9 @@ const (
 	// RequestGat is a get-and-touch operation that retrieves the information while updating the TTL
 	RequestGat
 
+	// RequestGetE is a custom get which returns the TTL remaining with the data
+	RequestGetE
+
 	// RequestSet is to insert a new piece of data unconditionally. What that means is different
 	// depending on L1 / L2 handling.
 	RequestSet
@@ -136,6 +139,7 @@ type Responder interface {
 	Replace(opaque uint32, replaced bool) error
 	Get(response GetResponse) error
 	GetEnd(opaque uint32, noopEnd bool) error
+	GetE(response GetEResponse) error
 	GAT(response GetResponse) error
 	Delete(opaque uint32) error
 	Touch(opaque uint32) error
@@ -211,4 +215,15 @@ type GetResponse struct {
 	Flags  uint32
 	Miss   bool
 	Quiet  bool
+}
+
+// GetEResponse is used in the GetE protocol extension
+type GetEResponse struct {
+	Key     []byte
+	Data    []byte
+	Opaque  uint32
+	Flags   uint32
+	Exptime uint32
+	Miss    bool
+	Quiet   bool
 }

--- a/handlers/memcached/chunked/handler.go
+++ b/handlers/memcached/chunked/handler.go
@@ -375,6 +375,10 @@ outer:
 	}
 }
 
+func (h Handler) GetE(cmd common.GetRequest) (<-chan common.GetEResponse, <-chan error) {
+	panic("GetE not supported in Rend")
+}
+
 func (h Handler) GAT(cmd common.GATRequest) (common.GetResponse, error) {
 	missResponse := common.GetResponse{
 		Miss:   true,

--- a/handlers/memcached/std/handler.go
+++ b/handlers/memcached/std/handler.go
@@ -165,6 +165,10 @@ func realHandleGet(cmd common.GetRequest, dataOut chan common.GetResponse, error
 	}
 }
 
+func (h Handler) GetE(cmd common.GetRequest) (<-chan common.GetEResponse, <-chan error) {
+	panic("GetE not supported in Rend")
+}
+
 func (h Handler) GAT(cmd common.GATRequest) (common.GetResponse, error) {
 	if err := binprot.WriteGATCmd(h.rw.Writer, cmd.Key, cmd.Exptime); err != nil {
 		return common.GetResponse{}, err

--- a/handlers/types.go
+++ b/handlers/types.go
@@ -21,6 +21,7 @@ type Handler interface {
 	Add(cmd common.SetRequest) error
 	Replace(cmd common.SetRequest) error
 	Get(cmd common.GetRequest) (<-chan common.GetResponse, <-chan error)
+	GetE(cmd common.GetRequest) (<-chan common.GetEResponse, <-chan error)
 	GAT(cmd common.GATRequest) (common.GetResponse, error)
 	Delete(cmd common.DeleteRequest) error
 	Touch(cmd common.TouchRequest) error

--- a/textprot/respond.go
+++ b/textprot/respond.go
@@ -88,6 +88,10 @@ func (t TextResponder) GetEnd(opaque uint32, noopEnd bool) error {
 	return t.resp("END")
 }
 
+func (t TextResponder) GetE(response common.GetEResponse) error {
+	panic("GetE command in text protocol")
+}
+
 func (t TextResponder) GAT(response common.GetResponse) error {
 	// There's two options here.
 	// 1) panic() because this is never supposed to be called


### PR DESCRIPTION
Adding a GetE command as a protocol extension. This command will not be recognized by Rend explicitly, but will be used to communicate with the L2 cache. When the L2 cache responds, the expiry time will come along with the response, allowing Rend to put the object into the L1 cache with the proper TTL. The portions of Rend which are reused by the L2 database have been updated to support a GetE command, including binary protocol parsing and responding, the handler interface, and some common package constants.

CC @smadappa @vuzilla @senugula 