### PR TITLE
Refactor level 3

### DIFF
--- a/binprot/respond.go
+++ b/binprot/respond.go
@@ -133,26 +133,18 @@ func (b BinaryResponder) Set(opaque uint32, quiet bool) error {
 	return nil
 }
 
-func (b BinaryResponder) Add(opaque uint32, added bool, quiet bool) error {
-	if added {
-		if !quiet {
-			return writeSuccessResponseHeader(b.writer, OpcodeAdd, 0, 0, 0, opaque, true)
-		}
-		return nil
-	} else {
-		return writeErrorResponseHeader(b.writer, OpcodeAdd, StatusKeyExists, opaque)
+func (b BinaryResponder) Add(opaque uint32, quiet bool) error {
+	if !quiet {
+		return writeSuccessResponseHeader(b.writer, OpcodeAdd, 0, 0, 0, opaque, true)
 	}
+	return nil
 }
 
-func (b BinaryResponder) Replace(opaque uint32, replaced bool, quiet bool) error {
-	if replaced {
-		if !quiet {
-			return writeSuccessResponseHeader(b.writer, OpcodeReplace, 0, 0, 0, opaque, true)
-		}
-		return nil
-	} else {
-		return writeErrorResponseHeader(b.writer, OpcodeReplace, StatusKeyEnoent, opaque)
+func (b BinaryResponder) Replace(opaque uint32, quiet bool) error {
+	if !quiet {
+		return writeSuccessResponseHeader(b.writer, OpcodeReplace, 0, 0, 0, opaque, true)
 	}
+	return nil
 }
 
 func (b BinaryResponder) Get(response common.GetResponse) error {

--- a/common/datatypes.go
+++ b/common/datatypes.go
@@ -138,8 +138,8 @@ type RequestParser interface {
 // corresponding RequestParser.
 type Responder interface {
 	Set(opaque uint32, quiet bool) error
-	Add(opaque uint32, added bool, quiet bool) error
-	Replace(opaque uint32, replaced bool, quiet bool) error
+	Add(opaque uint32, quiet bool) error
+	Replace(opaque uint32, quiet bool) error
 	Get(response GetResponse) error
 	GetEnd(opaque uint32, noopEnd bool) error
 	GetE(response GetEResponse) error

--- a/handlers/memcached/constructors.go
+++ b/handlers/memcached/constructors.go
@@ -23,7 +23,7 @@ import (
 	"github.com/netflix/rend/handlers/memcached/std"
 )
 
-func Regular(sock string) func() (handlers.Handler, error) {
+func Regular(sock string) handlers.HandlerConst {
 	return func() (handlers.Handler, error) {
 		conn, err := net.Dial("unix", sock)
 		if err != nil {
@@ -36,7 +36,7 @@ func Regular(sock string) func() (handlers.Handler, error) {
 	}
 }
 
-func Chunked(sock string) func() (handlers.Handler, error) {
+func Chunked(sock string) handlers.HandlerConst {
 	return func() (handlers.Handler, error) {
 		conn, err := net.Dial("unix", sock)
 		if err != nil {

--- a/handlers/types.go
+++ b/handlers/types.go
@@ -14,19 +14,16 @@
 
 package handlers
 
-import (
-	"io"
+import "github.com/netflix/rend/common"
 
-	"github.com/netflix/rend/common"
-)
-
-type HandlerConst func(conn io.ReadWriteCloser) Handler
+type HandlerConst func() (Handler, error)
+type HandlerConstConst func(sockpath string) HandlerConst
 
 // NilHandler is used as a placeholder for when there is no handler needed.
 // Since the Server API is a composition of a few things, including Handlers,
 // there needs to be a placeholder for when it's not needed.
-func NilHandler(conn io.ReadWriteCloser) Handler {
-	return nil
+func NilHandler(sockpath string) func() (Handler, error) {
+	return func() (Handler, error) { return nil, nil }
 }
 
 type Handler interface {

--- a/handlers/types.go
+++ b/handlers/types.go
@@ -22,7 +22,7 @@ type HandlerConstConst func(sockpath string) HandlerConst
 // NilHandler is used as a placeholder for when there is no handler needed.
 // Since the Server API is a composition of a few things, including Handlers,
 // there needs to be a placeholder for when it's not needed.
-func NilHandler(sockpath string) func() (Handler, error) {
+func NilHandler(sockpath string) HandlerConst {
 	return func() (Handler, error) { return nil, nil }
 }
 

--- a/memproxy.go
+++ b/memproxy.go
@@ -70,10 +70,9 @@ func init() {
 // And away we go
 func main() {
 	l := server.ListenArgs{
-		Port:      port,
-		L1sock:    l1sock,
-		L2enabled: l2enabled,
-		L2sock:    l2sock,
+		//Type: "tcp",
+		Port: port,
+		//Path: "",
 	}
 
 	var o orcas.OrcaConst
@@ -81,17 +80,17 @@ func main() {
 	var h1 handlers.HandlerConst
 
 	if chunked {
-		h1 = memcached.Chunked
+		h1 = memcached.Chunked(l1sock)
 	} else {
-		h1 = memcached.Regular
+		h1 = memcached.Regular(l1sock)
 	}
 
 	if l2enabled {
 		o = orcas.L1L2
-		h2 = memcached.Regular
+		h2 = memcached.Regular(l2sock)
 	} else {
 		o = orcas.L1Only
-		h2 = handlers.NilHandler
+		h2 = handlers.NilHandler(l2sock)
 	}
 
 	server.ListenAndServe(l, server.Default, o, h1, h2)

--- a/memproxy.go
+++ b/memproxy.go
@@ -76,12 +76,23 @@ func main() {
 		L2sock:    l2sock,
 	}
 
+	var o orcas.OrcaConst
+	var h2 handlers.HandlerConst
 	var h1 handlers.HandlerConst
+
 	if chunked {
 		h1 = memcached.Chunked
 	} else {
 		h1 = memcached.Regular
 	}
 
-	server.ListenAndServe(l, server.Default, orcas.L1Only, h1, handlers.NilHandler)
+	if l2enabled {
+		o = orcas.L1L2
+		h2 = memcached.Regular
+	} else {
+		o = orcas.L1Only
+		h2 = handlers.NilHandler
+	}
+
+	server.ListenAndServe(l, server.Default, o, h1, h2)
 }

--- a/memproxy.go
+++ b/memproxy.go
@@ -70,9 +70,8 @@ func init() {
 // And away we go
 func main() {
 	l := server.ListenArgs{
-		//Type: "tcp",
+		Type: server.ListenTCP,
 		Port: port,
-		//Path: "",
 	}
 
 	var o orcas.OrcaConst
@@ -90,7 +89,7 @@ func main() {
 		h2 = memcached.Regular(l2sock)
 	} else {
 		o = orcas.L1Only
-		h2 = handlers.NilHandler(l2sock)
+		h2 = handlers.NilHandler("")
 	}
 
 	server.ListenAndServe(l, server.Default, o, h1, h2)

--- a/orcas/l1only.go
+++ b/orcas/l1only.go
@@ -50,14 +50,11 @@ func (l *L1OnlyOrca) Add(req common.SetRequest) error {
 		metrics.IncCounter(MetricCmdAddStoredL1)
 		metrics.IncCounter(MetricCmdAddStored)
 
-		err = l.res.Add(req.Opaque, true, req.Quiet)
+		err = l.res.Add(req.Opaque, req.Quiet)
 
 	} else if err == common.ErrKeyExists {
 		metrics.IncCounter(MetricCmdAddNotStoredL1)
 		metrics.IncCounter(MetricCmdAddNotStored)
-
-		err = l.res.Add(req.Opaque, false, req.Quiet)
-
 	} else {
 		metrics.IncCounter(MetricCmdAddErrorsL1)
 		metrics.IncCounter(MetricCmdAddErrors)
@@ -77,14 +74,11 @@ func (l *L1OnlyOrca) Replace(req common.SetRequest) error {
 		metrics.IncCounter(MetricCmdReplaceStoredL1)
 		metrics.IncCounter(MetricCmdReplaceStored)
 
-		err = l.res.Replace(req.Opaque, true, req.Quiet)
+		err = l.res.Replace(req.Opaque, req.Quiet)
 
 	} else if err == common.ErrKeyNotFound {
 		metrics.IncCounter(MetricCmdReplaceNotStoredL1)
 		metrics.IncCounter(MetricCmdReplaceNotStored)
-
-		err = l.res.Replace(req.Opaque, false, req.Quiet)
-
 	} else {
 		metrics.IncCounter(MetricCmdReplaceErrorsL1)
 		metrics.IncCounter(MetricCmdReplaceErrors)

--- a/server/listen.go
+++ b/server/listen.go
@@ -19,7 +19,6 @@ import (
 type ListenArgs struct {
 	Port      int
 	L1sock    string
-	L1chunked bool
 	L2enabled bool
 	L2sock    string
 }

--- a/server/types.go
+++ b/server/types.go
@@ -14,6 +14,22 @@ type Server interface {
 	Loop()
 }
 
+type ListenType int
+
+const (
+	ListenTCP ListenType = iota
+	ListenUnix
+)
+
+type ListenArgs struct {
+	// The type of the connection. "tcp" or "unix" only.
+	Type ListenType
+	// TCP port to listen on, if applicable
+	Port int
+	// Unix domain socket path to listen on, if applicable
+	Path string
+}
+
 var (
 	MetricConnectionsEstablishedExt = metrics.AddCounter("conn_established_ext")
 	MetricConnectionsEstablishedL1  = metrics.AddCounter("conn_established_l1")

--- a/textprot/parser.go
+++ b/textprot/parser.go
@@ -176,7 +176,7 @@ func setRequest(r *bufio.Reader, clParts []string, reqType common.RequestType) (
 	}
 
 	// Consume the last two bytes "\r\n"
-	r.Discard(2)
+	r.ReadString(byte('\n'))
 	metrics.IncCounterBy(common.MetricBytesReadRemote, 2)
 
 	return common.SetRequest{

--- a/textprot/respond.go
+++ b/textprot/respond.go
@@ -36,20 +36,12 @@ func (t TextResponder) Set(opaque uint32, quiet bool) error {
 	return t.resp("STORED")
 }
 
-func (t TextResponder) Add(opaque uint32, added bool, quiet bool) error {
-	if added {
-		return t.resp("STORED")
-	} else {
-		return t.resp("NOT_STORED")
-	}
+func (t TextResponder) Add(opaque uint32, quiet bool) error {
+	return t.resp("STORED")
 }
 
-func (t TextResponder) Replace(opaque uint32, replaced bool, quiet bool) error {
-	if replaced {
-		return t.resp("STORED")
-	} else {
-		return t.resp("NOT_STORED")
-	}
+func (t TextResponder) Replace(opaque uint32, quiet bool) error {
+	return t.resp("STORED")
 }
 
 func (t TextResponder) Get(response common.GetResponse) error {


### PR DESCRIPTION
This pull request contains some *unfinished* L1 / L2 code! That particular code is not meant to be run in production yet. The args exist for L1 / L2 in the main program, but should not be used at this point. 

The purpose of this pull request is to merge the rest of the code base that has evolved around the server and handler composition. This is mainly to support other internal Netflix projects that are reusing this code. The driving use case has given a reason to clean up the admittedly leaky abstractions that existed before.

There's a few important bits:
* Handlers are now responsible for creating their own connection to the backend they handle.
* `HandlerConstConst` is a new type of constructor that returns a `HandlerConst` (constructor for a Handler). This generally returns a closure over the parameters needed to create a new connection.
* Handlers owning their connection means the server is no longer requiring an l1 unix path to connect. As well it means they are able to go off box (in theory) and are able to exist without a connection at all.
* server.ListenArgs is greatly simplified
* the server can listen on both TCP and UDP now

CC @vuzilla @smadappa @senugula for review