### PR TITLE
Multilevel support (a.k.a. Refactor level 4)

### DIFF
--- a/handlers/memcached/chunked/handler.go
+++ b/handlers/memcached/chunked/handler.go
@@ -376,7 +376,17 @@ outer:
 }
 
 func (h Handler) GetE(cmd common.GetRequest) (<-chan common.GetEResponse, <-chan error) {
-	panic("GetE not supported in Rend")
+	// Being minimalist, not lazy. The chunked handler is not meant to be used with a
+	// backing store that supports the GetE protocol extension. It would be a waste of
+	// time and effort to support it here if it would "never" be used. It will be added
+	// as soon as a case for it exists.
+	//
+	// The GetE extension is an addition that only rend supports. This chunked handler
+	// is pretty explicitly for talking to memcached since it is a complex workaround
+	// for pathological behavior when data size rapidly changes that only happens in
+	// memcached. The chunked handler will not work well with the L2 the EVCache team
+	// uses.
+	panic("GetE not supported in Rend chunked mode")
 }
 
 func (h Handler) GAT(cmd common.GATRequest) (common.GetResponse, error) {

--- a/handlers/memcached/std/handler.go
+++ b/handlers/memcached/std/handler.go
@@ -177,7 +177,6 @@ func (h Handler) GAT(cmd common.GATRequest) (common.GetResponse, error) {
 	data, flags, err := getLocal(h.rw)
 	if err != nil {
 		if err == common.ErrKeyNotFound {
-			//fmt.Println("GAT miss because of missing metadata. Key:", key)
 			return common.GetResponse{
 				Miss:   true,
 				Quiet:  false,

--- a/orcas/l1l2.go
+++ b/orcas/l1l2.go
@@ -177,7 +177,7 @@ func (l *L1L2Orca) Replace(req common.SetRequest) error {
 	err = l.l1.Replace(req)
 
 	if err != nil {
-		// In thi case, the replace worked fine, and we don't worry about it not
+		// In this case, the replace worked fine, and we don't worry about it not
 		// being replaced in L1 because it did not exist. In this case, L2 has
 		// the data and L1 is empty. This is still correct, and the next get
 		// would place the data back into L1. Hence, we do not return the error.
@@ -385,31 +385,138 @@ func (l *L1L2Orca) Gat(req common.GATRequest) error {
 	metrics.IncCounter(MetricCmdGat)
 	//log.Println("gat", string(req.Key))
 
+	// Try L1 first, since it'll be faster if it succeeds
 	metrics.IncCounter(MetricCmdGatL1)
 	res, err := l.l1.GAT(req)
 
-	if err == nil {
-		if res.Miss {
-			metrics.IncCounter(MetricCmdGatMissesL1)
-			// TODO: Account for L2
-			metrics.IncCounter(MetricCmdGatMisses)
-		} else {
-			metrics.IncCounter(MetricCmdGatHits)
-			metrics.IncCounter(MetricCmdGatHitsL1)
-		}
-		l.res.GAT(res)
-		// There is no GetEnd call required here since this is only ever
-		// done in the binary protocol, where there's no END marker.
-		// Calling l.res.GetEnd was a no-op here and is just useless.
-		//l.res.GetEnd(0, false)
-	} else {
-		metrics.IncCounter(MetricCmdGatErrors)
+	// Errors here are genrally fatal to the connection, as something has gone
+	// seriously wrong. Bail out early.
+	// I should note that this is different than the other commands, where there
+	// are some benevolent "errors" that include KeyNotFound or KeyExists. In
+	// both Get and GAT the mini-internal-protocol is different because the Get
+	// command uses a channel to send results back and an error channel to signal
+	// some kind of fatal problem. The result signals non-fatal "errors"; in this
+	// case it's ErrKeyNotFound --> res.Miss is true.
+	if err != nil {
 		metrics.IncCounter(MetricCmdGatErrorsL1)
+		metrics.IncCounter(MetricCmdGatErrors)
+		return err
 	}
 
-	//TODO: L2 metrics for gats, gat hits, gat misses, gat errors
+	if res.Miss {
+		// If we miss here, we have to GAT L2 to get the data, then put it back
+		// into L1 with the new TTL.
+		metrics.IncCounter(MetricCmdGatMissesL1)
 
-	return err
+		metrics.IncCounter(MetricCmdGatL2)
+		res, err = l.l2.GAT(req)
+
+		// fatal error
+		if err != nil {
+			metrics.IncCounter(MetricCmdGatErrorsL2)
+			metrics.IncCounter(MetricCmdGatErrors)
+			return err
+		}
+
+		// A miss on L2 after L1 is a true miss
+		if res.Miss {
+			metrics.IncCounter(MetricCmdGatMissesL2)
+			metrics.IncCounter(MetricCmdGatMisses)
+			return l.res.GAT(res)
+		}
+
+		// Take the data from the L2 GAT and set into L1 with the new TTL.
+		// There's several problems that could arise from interleaving of other
+		// operations. Another GAT isn't a problem.
+		//
+		// Intermediate sets might get clobbered in L1 but remain in L2 if we
+		// used Set, but since we use Add we should not overwrite a Set that
+		// happens between the L2 GAT hit and subsequent L1 reconciliation.
+		//
+		// Deletes would be a possible problem since a delete hit in L2 and miss
+		// in L1 would interleave to have data in L1 not in L2. This is a risk
+		// that is understood and accepted. The typical use cases at Netflix
+		// will not use deletes concurrently with GATs.
+		setreq := common.SetRequest{
+			Key:     req.Key,
+			Exptime: req.Exptime,
+			Flags:   res.Flags,
+			Data:    res.Data,
+		}
+
+		metrics.IncCounter(MetricCmdGatAddL1)
+		if err := l.l1.Add(setreq); err != nil {
+			// we were trampled in the middle of performing the GAT operation
+			// In this case, it's fine; no error for the overall op. We still
+			// want to track this with a metric, though, and return success.
+			if err == common.ErrKeyExists {
+				metrics.IncCounter(MetricCmdGatAddNotStoredL1)
+			} else {
+				metrics.IncCounter(MetricCmdGatAddErrorsL1)
+				// Gat errors here and not Add. The metrics for L1/L2 correspond to
+				// direct interaction with the two. THe overall metrics correspond
+				// to the more abstract orchestrator operation.
+				metrics.IncCounter(MetricCmdGatErrors)
+				return err
+			}
+		} else {
+			metrics.IncCounter(MetricCmdGatAddStoredL1)
+		}
+
+		// the overall operation succeeded
+		metrics.IncCounter(MetricCmdGatHits)
+
+	} else {
+		metrics.IncCounter(MetricCmdGatHitsL1)
+
+		// Set in L2 to play to the L2's strengths (fast writes) and avoid some
+		// pitfalls (slow touches and replaces, which require reads)
+		//
+		// The first possibility is a Set. A set into L2 would possibly cause a
+		// concurrent delete to not take, meaning the delete could say it was
+		// successful and then a subsequent get call would show the old data
+		// that was just deleted.
+		//
+		// Another option is to just send a touch, which allows us to send less
+		// data but gives the possibility of a touch miss on L2, which will be a
+		// problematic situation. If we get a touch miss, then we know we are
+		// inconsistent but we don't affect concurrent deletes.
+		//
+		// A third option is to use Replace, which could be helpful to avoid
+		// overriding concurrent deletes. This also might cause problems with
+		// othr sets at the same time, as it might overwrite a set that just
+		// finished.
+		//
+		// Many heavy users of EVCache at Netflix use GAT commands to lengthen
+		// TTLs of their data in use and to shorten the TTL of data they will
+		// not be using which is then async TTL'd out. I am explicitly
+		// discounting the concurrent delete situation here and accepting that
+		// they might not be exactly correct.
+		setreq := common.SetRequest{
+			Key:     req.Key,
+			Exptime: req.Exptime,
+			Flags:   res.Flags,
+			Data:    res.Data,
+		}
+
+		metrics.IncCounter(MetricCmdGatSetL2)
+		err := l.l2.Set(setreq)
+
+		if err != nil {
+			// set error? Return it as our error. Yes, the GAT succeeded in L1
+			// but if L2 didn't get the set, then likely something is seriously
+			// wrong.
+			metrics.IncCounter(MetricCmdGatSetErrorsL2)
+			metrics.IncCounter(MetricCmdGatErrors)
+			return err
+		}
+		metrics.IncCounter(MetricCmdGatSetSuccessL2)
+
+		// overall operation succeeded
+		metrics.IncCounter(MetricCmdGatHits)
+	}
+
+	return l.res.GAT(res)
 }
 
 func (l *L1L2Orca) Noop(req common.NoopRequest) error {

--- a/orcas/l1l2.go
+++ b/orcas/l1l2.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orcas
 
 import (

--- a/orcas/l1l2.go
+++ b/orcas/l1l2.go
@@ -184,7 +184,7 @@ func (l *L1L2Orca) Replace(req common.SetRequest) error {
 		if err == common.ErrKeyNotFound {
 			metrics.IncCounter(MetricCmdReplaceNotStoredL1)
 			metrics.IncCounter(MetricCmdReplaceNotStored)
-			return nil
+			return l.res.Replace(req.Opaque, req.Quiet)
 		}
 
 		// otherwise we have a real error on our hands
@@ -242,9 +242,9 @@ func (l *L1L2Orca) Delete(req common.DeleteRequest) error {
 		// data might have TTL'd out. Both cases are still fine.
 		if err == common.ErrKeyNotFound {
 			metrics.IncCounter(MetricCmdDeleteMissesL1)
-			metrics.IncCounter(MetricCmdDeleteMisses)
+			metrics.IncCounter(MetricCmdDeleteHits)
 			// disregard the miss, don't return the error
-			return nil
+			return l.res.Delete(req.Opaque)
 		}
 		metrics.IncCounter(MetricCmdDeleteErrorsL1)
 		metrics.IncCounter(MetricCmdDeleteErrors)
@@ -302,7 +302,7 @@ func (l *L1L2Orca) Touch(req common.TouchRequest) error {
 			// Note that we increment the overall hits here (not misses) on
 			// purpose because L2 hit.
 			metrics.IncCounter(MetricCmdTouchHits)
-			return nil
+			return l.res.Touch(req.Opaque)
 		}
 
 		metrics.IncCounter(MetricCmdTouchErrorsL1)

--- a/orcas/l1l2.go
+++ b/orcas/l1l2.go
@@ -631,5 +631,10 @@ func (l *L1L2Orca) Unknown(req common.Request) error {
 }
 
 func (l *L1L2Orca) Error(req common.Request, reqType common.RequestType, err error) {
-	l.res.Error(req.Opq(), reqType, err)
+	opaque := uint32(0)
+	if req != nil {
+		opaque = req.Opq()
+	}
+
+	l.res.Error(opaque, reqType, err)
 }

--- a/orcas/l1l2.go
+++ b/orcas/l1l2.go
@@ -397,8 +397,8 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 		Quiet:      l2quiets,
 	}
 
-	metrics.IncCounter(MetricCmdGetL2)
-	metrics.IncCounterBy(MetricCmdGetKeysL2, uint64(len(l2keys)))
+	metrics.IncCounter(MetricCmdGetEL2)
+	metrics.IncCounterBy(MetricCmdGetEKeysL2, uint64(len(l2keys)))
 	resChanE, errChan := l.l2.GetE(req)
 	for {
 		select {
@@ -407,11 +407,11 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 				resChanE = nil
 			} else {
 				if res.Miss {
-					metrics.IncCounter(MetricCmdGetMissesL2)
+					metrics.IncCounter(MetricCmdGetEMissesL2)
 					// Missing L2 means a true miss
 					metrics.IncCounter(MetricCmdGetMisses)
 				} else {
-					metrics.IncCounter(MetricCmdGetHitsL2)
+					metrics.IncCounter(MetricCmdGetEHitsL2)
 
 					//set in l1
 					metrics.IncCounter(MetricCmdGetSetL1)
@@ -450,7 +450,7 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 				errChan = nil
 			} else {
 				metrics.IncCounter(MetricCmdGetErrors)
-				metrics.IncCounter(MetricCmdGetErrorsL2)
+				metrics.IncCounter(MetricCmdGetEErrorsL2)
 				err = getErr
 			}
 		}

--- a/orcas/l1only.go
+++ b/orcas/l1only.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orcas
 
 import (

--- a/orcas/l1only.go
+++ b/orcas/l1only.go
@@ -320,5 +320,10 @@ func (l *L1OnlyOrca) Unknown(req common.Request) error {
 }
 
 func (l *L1OnlyOrca) Error(req common.Request, reqType common.RequestType, err error) {
-	l.res.Error(req.Opq(), reqType, err)
+	opaque := uint32(0)
+	if req != nil {
+		opaque = req.Opq()
+	}
+
+	l.res.Error(opaque, reqType, err)
 }

--- a/orcas/types.go
+++ b/orcas/types.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package orcas
 
 import (

--- a/orcas/types.go
+++ b/orcas/types.go
@@ -115,10 +115,18 @@ var (
 	MetricCmdGatErrorsL1 = metrics.AddCounter("cmd_gat_errors_l1")
 	MetricCmdGatErrorsL2 = metrics.AddCounter("cmd_gat_errors_l2")
 
+	// Secondary metrics under GAT that refer to other kinds of operations to
+	// backing datastores as a part of the overall request
+	MetricCmdGatAddL1          = metrics.AddCounter("cmd_gat_add_l1")
+	MetricCmdGatAddErrorsL1    = metrics.AddCounter("cmd_gat_add_errors_l1")
+	MetricCmdGatAddStoredL1    = metrics.AddCounter("cmd_gat_add_stored_l1")
+	MetricCmdGatAddNotStoredL1 = metrics.AddCounter("cmd_gat_add_not_stored_l1")
+	MetricCmdGatSetL2          = metrics.AddCounter("cmd_gat_set_l2")
+	MetricCmdGatSetErrorsL2    = metrics.AddCounter("cmd_gat_set_errors_l2")
+	MetricCmdGatSetSuccessL2   = metrics.AddCounter("cmd_gat_set_success_l2")
+
 	MetricCmdUnknown = metrics.AddCounter("cmd_unknown")
 	MetricCmdNoop    = metrics.AddCounter("cmd_noop")
 	MetricCmdQuit    = metrics.AddCounter("cmd_quit")
 	MetricCmdVersion = metrics.AddCounter("cmd_version")
-
-	// TODO: inconsistency metrics for when L1 is not a subset of L2
 )

--- a/orcas/types.go
+++ b/orcas/types.go
@@ -29,6 +29,7 @@ type Orca interface {
 	Delete(req common.DeleteRequest) error
 	Touch(req common.TouchRequest) error
 	Get(req common.GetRequest) error
+	GetE(req common.GetRequest) error
 	Gat(req common.GATRequest) error
 	Noop(req common.NoopRequest) error
 	Quit(req common.QuitRequest) error
@@ -53,6 +54,26 @@ var (
 	MetricCmdGetKeys     = metrics.AddCounter("cmd_get_keys")
 	MetricCmdGetKeysL1   = metrics.AddCounter("cmd_get_keys_l1")
 	MetricCmdGetKeysL2   = metrics.AddCounter("cmd_get_keys_l2")
+
+	MetricCmdGetSetL1       = metrics.AddCounter("cmd_get_set_l1")
+	MetricCmdGetSetErrorsL1 = metrics.AddCounter("cmd_get_set_errors_l1")
+	MetricCmdGetSetSucessL1 = metrics.AddCounter("cmd_get_set_success_l1")
+
+	MetricCmdGetE         = metrics.AddCounter("cmd_gete")
+	MetricCmdGetEL1       = metrics.AddCounter("cmd_gete_l1")
+	MetricCmdGetEL2       = metrics.AddCounter("cmd_gete_l2")
+	MetricCmdGetEHits     = metrics.AddCounter("cmd_gete_hits")
+	MetricCmdGetEHitsL1   = metrics.AddCounter("cmd_gete_hits_l1")
+	MetricCmdGetEHitsL2   = metrics.AddCounter("cmd_gete_hits_l2")
+	MetricCmdGetEMisses   = metrics.AddCounter("cmd_gete_misses")
+	MetricCmdGetEMissesL1 = metrics.AddCounter("cmd_gete_misses_l1")
+	MetricCmdGetEMissesL2 = metrics.AddCounter("cmd_gete_misses_l2")
+	MetricCmdGetEErrors   = metrics.AddCounter("cmd_gete_errors")
+	MetricCmdGetEErrorsL1 = metrics.AddCounter("cmd_gete_errors_l1")
+	MetricCmdGetEErrorsL2 = metrics.AddCounter("cmd_gete_errors_l2")
+	MetricCmdGetEKeys     = metrics.AddCounter("cmd_gete_keys")
+	MetricCmdGetEKeysL1   = metrics.AddCounter("cmd_gete_keys_l1")
+	MetricCmdGetEKeysL2   = metrics.AddCounter("cmd_gete_keys_l2")
 
 	MetricCmdSet          = metrics.AddCounter("cmd_set")
 	MetricCmdSetL1        = metrics.AddCounter("cmd_set_l1")

--- a/server/default.go
+++ b/server/default.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/default.go
+++ b/server/default.go
@@ -82,6 +82,8 @@ func (s *DefaultServer) Loop() {
 			err = s.orca.Touch(request.(common.TouchRequest))
 		case common.RequestGet:
 			err = s.orca.Get(request.(common.GetRequest))
+		case common.RequestGetE:
+			err = s.orca.GetE(request.(common.GetRequest))
 		case common.RequestGat:
 			err = s.orca.Gat(request.(common.GATRequest))
 		case common.RequestNoop:

--- a/server/listen.go
+++ b/server/listen.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/types.go
+++ b/server/types.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/server/utils.go
+++ b/server/utils.go
@@ -1,3 +1,17 @@
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (


### PR DESCRIPTION
This is the final PR for the L1/L2 functionality. This includes full support for L1/L2 interactions with the same API as the standard memcached-backed L1 only scheme. It does assume an L2 server that is also running rend (for now) because we use the GetE command to retrieve the expiration time from L2 along with the data when we need it. This is an extension to the memcached protocol that we use to be more efficient with our implementation.

CC @vuzilla @senugula for review