### PR TITLE
Histogram improvements

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,25 @@
+Some code is copied or derived from from Damian Gryski's go-bits package
+https://github.com/dgryski/go-bits
+Copyright 2015 Damian Gryski, under MIT license:
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Damian Gryski <damian@gryski.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/metrics/lzcnt.go
+++ b/metrics/lzcnt.go
@@ -1,0 +1,54 @@
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !amd64
+
+package metrics
+
+// Function copied from Damian Gryski's go-bits package
+// Copyright 2015 Damian Gryski, under MIT license
+// See the NOTICE file for more details.
+// https://github.com/dgryski/go-bits
+func lzcnt(x uint64) uint64 {
+	var n uint64
+
+	n = 1
+
+	if (x >> 32) == 0 {
+		n = n + 32
+		x = x << 32
+	}
+	if (x >> (32 + 16)) == 0 {
+		n = n + 16
+		x = x << 16
+	}
+
+	if (x >> (32 + 16 + 8)) == 0 {
+		n = n + 8
+		x = x << 8
+	}
+
+	if (x >> (32 + 16 + 8 + 4)) == 0 {
+		n = n + 4
+		x = x << 4
+	}
+
+	if (x >> (32 + 16 + 8 + 4 + 2)) == 0 {
+		n = n + 2
+		x = x << 2
+	}
+
+	n = n - (x >> 63)
+	return uint64(n)
+}

--- a/metrics/lzcnt_amd64.s
+++ b/metrics/lzcnt_amd64.s
@@ -1,0 +1,32 @@
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build amd64
+
+// #Function copied from Damian Gryski's go-bits package
+// #Copyright 2015 Damian Gryski, under MIT license
+// #See the NOTICE file for more details.
+// #https://github.com/dgryski/go-bits
+
+// func lzcnt(x uint64) uint64
+TEXT ·lzcnt(SB),4,$0-16
+        BSRQ  x+0(FP), AX
+        JZ zero
+        SUBQ  $63, AX
+        NEGQ AX
+        MOVQ AX, ret+8(FP)
+        RET
+zero:
+        MOVQ $64, ret+8(FP)
+        RET

--- a/metrics/lzcnt_asm.go
+++ b/metrics/lzcnt_asm.go
@@ -1,0 +1,19 @@
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//+build amd64
+
+package metrics
+
+func lzcnt(x uint64) uint64

--- a/metrics/lzcnt_test.go
+++ b/metrics/lzcnt_test.go
@@ -1,0 +1,41 @@
+// Copyright 2015 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package metrics
+
+import (
+	"testing"
+	"testing/quick"
+)
+
+// Derived from Damian Gryski's go-bits package
+// Copyright 2015 Damian Gryski, under MIT license
+// See the NOTICE file for more details.
+// https://github.com/dgryski/go-bitspackage metrics
+func TestQuickLzcnt(t *testing.T) {
+	f := func(x uint64) bool {
+		return lzcnt(x) == lzcntSlowForTestingOnly(x)
+	}
+	if err := quick.Check(f, nil); err != nil {
+		t.Errorf("lzcnt != lzcntSlowForTestingOnly: %v: ", err)
+	}
+}
+
+func lzcntSlowForTestingOnly(x uint64) uint64 {
+	var n uint64
+	for x&0x8000000000000000 == 0 {
+		n++
+		x <<= 1
+	}
+	return n
+}

--- a/metrics/lzcnt_test.go
+++ b/metrics/lzcnt_test.go
@@ -21,7 +21,7 @@ import (
 // Derived from Damian Gryski's go-bits package
 // Copyright 2015 Damian Gryski, under MIT license
 // See the NOTICE file for more details.
-// https://github.com/dgryski/go-bitspackage metrics
+// https://github.com/dgryski/go-bits
 func TestQuickLzcnt(t *testing.T) {
 	f := func(x uint64) bool {
 		return lzcnt(x) == lzcntSlowForTestingOnly(x)

--- a/server/types.go
+++ b/server/types.go
@@ -52,13 +52,13 @@ var (
 	MetricErrAppError               = metrics.AddCounter("err_app_err")
 	MetricErrUnrecoverable          = metrics.AddCounter("err_unrecoverable")
 
-	HistSet     = metrics.AddHistogram("set")
-	HistAdd     = metrics.AddHistogram("add")
-	HistReplace = metrics.AddHistogram("replace")
-	HistDelete  = metrics.AddHistogram("delete")
-	HistTouch   = metrics.AddHistogram("touch")
-	HistGet     = metrics.AddHistogram("get")
-	HistGat     = metrics.AddHistogram("gat")
+	HistSet     = metrics.AddHistogram("set", false)
+	HistAdd     = metrics.AddHistogram("add", false)
+	HistReplace = metrics.AddHistogram("replace", false)
+	HistDelete  = metrics.AddHistogram("delete", false)
+	HistTouch   = metrics.AddHistogram("touch", false)
+	HistGet     = metrics.AddHistogram("get", true) // sampled
+	HistGat     = metrics.AddHistogram("gat", true) // sampled
 
 	// TODO: inconsistency metrics for when L1 is not a subset of L2
 )


### PR DESCRIPTION
Two things for histograms in this PR:

1) Adding an option to sample or not in the regular histograms, since some operations are much higher traffic than others. get and get-and-touch are sampled at 25% while the rest are not.

Closes #37 

2) Bucketized histograms. These are standardized power-of-two buckets for the full range of the 64 bit unsigned integer space. These are reported alongside the original histograms because the aggregate better across a whole fleet of servers. They are less accurate in terms of percentiles, however.

Closes #55 