### PR TITLE
Locking orcas

### DIFF
--- a/client/binprot/headers.go
+++ b/client/binprot/headers.go
@@ -52,7 +52,7 @@ const (
 	Touch      = 0x1c
 	GAT        = 0x1d
 	GATQ       = 0x1e
-        GetE       = 0x40
+	GetE       = 0x40
 )
 
 type req struct {
@@ -106,6 +106,7 @@ func writeReq(w io.Writer, opcode, keylen, extralen, bodylen, opaque int) error 
 	}
 
 	_, err := w.Write(buf)
+	//fmt.Printf("% x\n", buf)
 	bufPool.Put(buf)
 	return err
 }

--- a/client/binprot/prot.go
+++ b/client/binprot/prot.go
@@ -17,6 +17,7 @@ package binprot
 import (
 	"bufio"
 	"encoding/binary"
+	"errors"
 	"io"
 
 	"github.com/netflix/rend/client/common"
@@ -24,17 +25,19 @@ import (
 
 type BinProt struct{}
 
+var ErrOpaqueMismatch = errors.New("Opaques do not match")
+
 func consumeResponseE(r *bufio.Reader) ([]byte, uint32, uint32, error) {
-        res, err := readRes(r)
-        if err != nil {
-                return nil, 0, 0, err
-        }
+	res, err := readRes(r)
+	if err != nil {
+		return nil, 0, 0, err
+	}
 
-        apperr := statusToError(res.Status)
+	apperr := statusToError(res.Status)
 
-        // read body in regardless of the error in the header
-        buf := make([]byte, res.BodyLen)
-        io.ReadFull(r, buf)
+	// read body in regardless of the error in the header
+	buf := make([]byte, res.BodyLen)
+	io.ReadFull(r, buf)
 
 	var flags uint32 = 0
 	var expiration uint32 = 0
@@ -42,17 +45,17 @@ func consumeResponseE(r *bufio.Reader) ([]byte, uint32, uint32, error) {
 		flags = binary.BigEndian.Uint32(buf[0:4])
 	}
 	if res.ExtraLen >= 8 {
-        	expiration = binary.BigEndian.Uint32(buf[4:8])
+		expiration = binary.BigEndian.Uint32(buf[4:8])
 	}
-        buf = buf[res.ExtraLen:]
+	buf = buf[res.ExtraLen:]
 
-        resPool.Put(res)
+	resPool.Put(res)
 
-        if apperr != nil && srsErr(apperr) {
-                return buf, flags, expiration, apperr
-        }
+	if apperr != nil && srsErr(apperr) {
+		return buf, flags, expiration, apperr
+	}
 
-        return buf, flags, expiration, err
+	return buf, flags, expiration, err
 }
 
 func consumeResponse(r *bufio.Reader) ([]byte, error) {
@@ -85,10 +88,6 @@ func consumeResponseCheckOpaque(r *bufio.Reader, opaque int) ([]byte, error) {
 		return nil, err
 	}
 
-	if res.Opaque != uint32(opaque) {
-		panic("SHIT")
-	}
-
 	apperr := statusToError(res.Status)
 
 	// read body in regardless of the error in the header
@@ -102,6 +101,10 @@ func consumeResponseCheckOpaque(r *bufio.Reader, opaque int) ([]byte, error) {
 
 	if apperr != nil && srsErr(apperr) {
 		return buf, apperr
+	}
+
+	if res.Opaque != uint32(opaque) {
+		return buf, ErrOpaqueMismatch
 	}
 
 	return buf, err
@@ -221,15 +224,15 @@ func (b BinProt) Get(rw *bufio.ReadWriter, key []byte) ([]byte, error) {
 }
 
 func (b BinProt) GetE(rw *bufio.ReadWriter, key []byte) ([]byte, uint32, uint32, error) {
-        // Header
-        writeReq(rw, GetE, len(key), 0, len(key), 0)
-        // Body
-        rw.Write(key)
+	// Header
+	writeReq(rw, GetE, len(key), 0, len(key), 0)
+	// Body
+	rw.Write(key)
 
-        rw.Flush()
+	rw.Flush()
 
-        // consume all of the response and return
-        return consumeResponseE(rw.Reader)
+	// consume all of the response and return
+	return consumeResponseE(rw.Reader)
 }
 
 func (b BinProt) GetWithOpaque(rw *bufio.ReadWriter, key []byte, opaque int) ([]byte, error) {

--- a/client/setget.go
+++ b/client/setget.go
@@ -17,6 +17,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"io"
 	"log"
 	"math"
 	"math/rand"
@@ -141,6 +142,11 @@ func worker(prot common.Prot, rw *bufio.ReadWriter, keys chan []byte, wg *sync.W
 		// continue on even if there's errors here
 		if err := prot.Set(rw, key, value); err != nil {
 			log.Println("Error during set:", err.Error())
+			if err == io.EOF {
+				log.Println("End of file. Aborting!")
+				wg.Done()
+				return
+			}
 		}
 
 		opaque := r.Int()
@@ -149,6 +155,11 @@ func worker(prot common.Prot, rw *bufio.ReadWriter, keys chan []byte, wg *sync.W
 		ret, err := prot.GetWithOpaque(rw, key, opaque)
 		if err != nil {
 			log.Println("Error getting data for key", string(key), ":", err.Error())
+			if err == io.EOF {
+				log.Println("End of file. Aborting!")
+				wg.Done()
+				return
+			}
 			continue
 		}
 

--- a/orcas/locking.go
+++ b/orcas/locking.go
@@ -1,0 +1,167 @@
+// Copyright 2016 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orcas
+
+import (
+	"hash"
+	"hash/fnv"
+	"sync"
+
+	"github.com/netflix/rend/common"
+	"github.com/netflix/rend/handlers"
+)
+
+type LockingOrca struct {
+	wrapped Orca
+	locks   []sync.RWMutex
+	hpool   *sync.Pool
+}
+
+// Locking wraps an orcas.Orca to provide locking around operations on the same
+// key. The concurrency param allows 2^(concurrency) operations to happen in
+// parallel. E.g. concurrency of 1 would allow 2 parallel operations, while a
+// concurrency of 4 allows 2^4 = 16 parallel operations.
+func Locking(oc OrcaConst, concurrency uint16) OrcaConst {
+	if concurrency < 0 {
+		panic("Concurrency level must be at least 0")
+	}
+
+	// keep the same locks for all instances by closing over this slice
+	locks := make([]sync.RWMutex, 1<<concurrency)
+	pool := &sync.Pool{
+		New: func() interface{} {
+			return fnv.New32a()
+		},
+	}
+
+	return func(l1, l2 handlers.Handler, res common.Responder) Orca {
+		return &LockingOrca{
+			wrapped: oc(l1, l2, res),
+			locks:   locks,
+			hpool:   pool,
+		}
+	}
+}
+
+func (l *LockingOrca) getlock(key []byte) *sync.RWMutex {
+	h := l.hpool.Get().(hash.Hash32)
+	h.Reset()
+
+	// Calculate bucket using hash and mod. FNV1a never returns an error.
+	bucket, _ := h.Write(key)
+	bucket &= len(l.locks) - 1
+
+	return &l.locks[bucket]
+}
+
+func (l *LockingOrca) Set(req common.SetRequest) error {
+	lock := l.getlock(req.Key)
+	lock.Lock()
+	ret := l.wrapped.Set(req)
+	lock.Unlock()
+	return ret
+}
+
+func (l *LockingOrca) Add(req common.SetRequest) error {
+	lock := l.getlock(req.Key)
+	lock.Lock()
+	ret := l.wrapped.Add(req)
+	lock.Unlock()
+	return ret
+}
+
+func (l *LockingOrca) Replace(req common.SetRequest) error {
+	lock := l.getlock(req.Key)
+	lock.Lock()
+	ret := l.wrapped.Replace(req)
+	lock.Unlock()
+	return ret
+}
+
+func (l *LockingOrca) Delete(req common.DeleteRequest) error {
+	lock := l.getlock(req.Key)
+	lock.Lock()
+	ret := l.wrapped.Delete(req)
+	lock.Unlock()
+	return ret
+}
+
+func (l *LockingOrca) Touch(req common.TouchRequest) error {
+	lock := l.getlock(req.Key)
+	lock.Lock()
+	ret := l.wrapped.Touch(req)
+	lock.Unlock()
+	return ret
+}
+
+func (l *LockingOrca) Get(req common.GetRequest) error {
+	// Acquire read locks for all keys
+	for _, key := range req.Keys {
+		l.getlock(key).RLock()
+	}
+
+	ret := l.wrapped.Get(req)
+
+	// Release all read locks
+	for _, key := range req.Keys {
+		l.getlock(key).RUnlock()
+	}
+
+	return ret
+}
+
+func (l *LockingOrca) GetE(req common.GetRequest) error {
+	// Acquire read locks for all keys
+	for _, key := range req.Keys {
+		l.getlock(key).RLock()
+	}
+
+	ret := l.wrapped.GetE(req)
+
+	// Release all read locks
+	for _, key := range req.Keys {
+		l.getlock(key).RUnlock()
+	}
+
+	return ret
+}
+
+func (l *LockingOrca) Gat(req common.GATRequest) error {
+	lock := l.getlock(req.Key)
+	lock.Lock()
+	ret := l.wrapped.Gat(req)
+	lock.Unlock()
+	return ret
+}
+
+func (l *LockingOrca) Noop(req common.NoopRequest) error {
+	return l.wrapped.Noop(req)
+}
+
+func (l *LockingOrca) Quit(req common.QuitRequest) error {
+	return l.wrapped.Quit(req)
+}
+
+func (l *LockingOrca) Version(req common.VersionRequest) error {
+	return l.wrapped.Version(req)
+}
+
+func (l *LockingOrca) Unknown(req common.Request) error {
+	return l.wrapped.Unknown(req)
+}
+
+func (l *LockingOrca) Error(req common.Request, reqType common.RequestType, err error) {
+	l.wrapped.Error(req, reqType, err)
+}


### PR DESCRIPTION
This introduces a wrapper orchestrator that will apply locking to the operations based on the key. It is configurable to have either sync.Mutex or sync.RWMutex semantics, the former of which is enforced if using data chunking. By default it

* is off
* uses RWMutex semantics
* allows 256 parallel operations at the same time (infinite readers)

CC @vuzilla @senugula @smadappa for review