### PR TITLE
Removing handlers.HandlerConstConst

### DIFF
--- a/handlers/types.go
+++ b/handlers/types.go
@@ -17,14 +17,11 @@ package handlers
 import "github.com/netflix/rend/common"
 
 type HandlerConst func() (Handler, error)
-type HandlerConstConst func(sockpath string) HandlerConst
 
 // NilHandler is used as a placeholder for when there is no handler needed.
 // Since the Server API is a composition of a few things, including Handlers,
 // there needs to be a placeholder for when it's not needed.
-func NilHandler(sockpath string) HandlerConst {
-	return func() (Handler, error) { return nil, nil }
-}
+func NilHandler() (Handler, error) { return nil, nil }
 
 type Handler interface {
 	Set(cmd common.SetRequest) error

--- a/memproxy.go
+++ b/memproxy.go
@@ -129,7 +129,7 @@ func main() {
 		h2 = memcached.Regular(l2sock)
 	} else {
 		o = orcas.L1Only
-		h2 = handlers.NilHandler("")
+		h2 = handlers.NilHandler
 	}
 
 	// Add the locking wrapper if requested. The locking wrapper can either allow mutltiple readers


### PR DESCRIPTION
This PR closes #72 

The extraneous type was useless and had some code smell associated with it. It's gone now, along with its extraneous function call cousin.