### PR TITLE
Large batch get optimization

### DIFF
--- a/handlers/memcached/chunked/handler.go
+++ b/handlers/memcached/chunked/handler.go
@@ -311,20 +311,20 @@ outer:
 
 		missResponse.Flags = metaData.OrigFlags
 
-		cmdSize := int(metaData.NumChunks) * (len(key) + 4 /* key suffix */ + binprot.ReqHeaderLen)
+		cmdSize := int(metaData.NumChunks)*(len(key)+4 /* key suffix */ +binprot.ReqHeaderLen) + binprot.ReqHeaderLen /* for the noop */
 		cmdbuf := bytes.NewBuffer(make([]byte, 0, cmdSize))
 		// Write all the get commands before reading
 		for i := 0; i < int(metaData.NumChunks); i++ {
 			chunkKey := chunkKey(key, i)
 			// bytes.Buffer doesn't error
-			binprot.WriteGetQCmd(rw.Writer, chunkKey)
+			binprot.WriteGetQCmd(cmdbuf, chunkKey)
 		}
 
 		// The final command must be Get or Noop to guarantee a response
 		// We use Noop to make coding easier, but it's (very) slightly less efficient
 		// since we send 24 extra bytes in each direction
 		// bytes.Buffer doesn't error
-		binprot.WriteNoopCmd(rw.Writer)
+		binprot.WriteNoopCmd(cmdbuf)
 
 		// bufio's ReadFrom will end up doing an io.Copy(cmdbuf, socket), which is more
 		// efficient than writing directly into the bufio or using cmdbuf.WriteTo(rw)

--- a/handlers/memcached/chunked/handler.go
+++ b/handlers/memcached/chunked/handler.go
@@ -311,14 +311,11 @@ outer:
 
 		missResponse.Flags = metaData.OrigFlags
 
-		cmdbuf := bytes.NewBuffer(make([]byte, 0, int(metaData.NumChunks)*(len(key)+4 /* key suffix */ +binprot.ReqHeaderLen)))
+		cmdSize := int(metaData.NumChunks) * (len(key) + 4 /* key suffix */ + binprot.ReqHeaderLen)
+		cmdbuf := bytes.NewBuffer(make([]byte, 0, cmdSize))
 		// Write all the get commands before reading
 		for i := 0; i < int(metaData.NumChunks); i++ {
 			chunkKey := chunkKey(key, i)
-			/*if err := binprot.WriteGetQCmd(rw.Writer, chunkKey); err != nil {
-				errorOut <- err
-				return
-			}*/
 			// bytes.Buffer doesn't error
 			binprot.WriteGetQCmd(rw.Writer, chunkKey)
 		}
@@ -326,14 +323,12 @@ outer:
 		// The final command must be Get or Noop to guarantee a response
 		// We use Noop to make coding easier, but it's (very) slightly less efficient
 		// since we send 24 extra bytes in each direction
-		/*if err := binprot.WriteNoopCmd(rw.Writer); err != nil {
-			errorOut <- err
-			return
-		}*/
 		// bytes.Buffer doesn't error
 		binprot.WriteNoopCmd(rw.Writer)
 
-		if _, err := cmdbuf.WriteTo(rw); err != nil {
+		// bufio's ReadFrom will end up doing an io.Copy(cmdbuf, socket), which is more
+		// efficient than writing directly into the bufio or using cmdbuf.WriteTo(rw)
+		if _, err := rw.ReadFrom(cmdbuf); err != nil {
 			errorOut <- err
 			return
 		}

--- a/handlers/memcached/chunked/handler.go
+++ b/handlers/memcached/chunked/handler.go
@@ -311,19 +311,29 @@ outer:
 
 		missResponse.Flags = metaData.OrigFlags
 
+		cmdbuf := bytes.NewBuffer(make([]byte, 0, int(metaData.NumChunks)*(len(key)+4 /* key suffix */ +binprot.ReqHeaderLen)))
 		// Write all the get commands before reading
 		for i := 0; i < int(metaData.NumChunks); i++ {
 			chunkKey := chunkKey(key, i)
-			if err := binprot.WriteGetQCmd(rw.Writer, chunkKey); err != nil {
+			/*if err := binprot.WriteGetQCmd(rw.Writer, chunkKey); err != nil {
 				errorOut <- err
 				return
-			}
+			}*/
+			// bytes.Buffer doesn't error
+			binprot.WriteGetQCmd(rw.Writer, chunkKey)
 		}
 
 		// The final command must be Get or Noop to guarantee a response
 		// We use Noop to make coding easier, but it's (very) slightly less efficient
 		// since we send 24 extra bytes in each direction
-		if err := binprot.WriteNoopCmd(rw.Writer); err != nil {
+		/*if err := binprot.WriteNoopCmd(rw.Writer); err != nil {
+			errorOut <- err
+			return
+		}*/
+		// bytes.Buffer doesn't error
+		binprot.WriteNoopCmd(rw.Writer)
+
+		if _, err := cmdbuf.WriteTo(rw); err != nil {
 			errorOut <- err
 			return
 		}


### PR DESCRIPTION
This change is to address large values in chunked mode.

For each value in a chunked get request, we write the header to the socket. Previously, this was through a buffered writer. For requests that generated more than 4k of headers, we would write into the bufio buffer, flush (implicitly, when it gets full), write, flush, write, flush, etc. This change instead buffers all of the headers for an individual chunked get request into one big buffer before sending via `bufio.Writer.ReadFrom()`. This will directly write all of the headers at once, avoiding the multiple flushes, each of which cause a `write()` syscall to send to the unix domain socket fd.

Unfortunately, this doesn't completely solve the problem it was meant to address. We were seeing memcached connection yields for these large requests anyway, so the other half of the solution was to increase the connection yield limit to avoid taking a very long time to get the data back. Even if we send headers all at once, memcached would consider each individual get a request and stop after 20 chunks, starving the caller until all other connections had a turn.

CC @smadappa @vuzilla @senugula for review