### PR TITLE
Passing sync.WaitGroup by reference in client sizes testing program

### DIFF
--- a/client/sizes.go
+++ b/client/sizes.go
@@ -36,11 +36,11 @@ func main() {
 		prot = t
 	}
 
-	var wg sync.WaitGroup
+	wg := &sync.WaitGroup{}
 	wg.Add(f.NumWorkers)
 
 	for i := 0; i < f.NumWorkers; i++ {
-		go func(prot common.Prot, wg sync.WaitGroup) {
+		go func(prot common.Prot, wg *sync.WaitGroup) {
 			conn, err := common.Connect("localhost", f.Port)
 			if err != nil {
 				panic("Couldn't connect")


### PR DESCRIPTION
Previously it was passed by value, meaning the program would never stop.

Closes #78 

CC @smadappa @vuzilla @senugula @akpratt 
and @dgryski 