### PR TITLE
Rework batch port operations to more actively manage L1

### DIFF
--- a/orcas/l1l2batch.go
+++ b/orcas/l1l2batch.go
@@ -65,9 +65,10 @@ func (l *L1L2BatchOrca) Set(req common.SetRequest) error {
 			metrics.IncCounter(MetricCmdSetErrors)
 			return err
 		}
+	} else {
+		metrics.IncCounter(MetricCmdSetReplaceStoredL1)
 	}
 
-	metrics.IncCounter(MetricCmdSetReplaceStoredL1)
 	metrics.IncCounter(MetricCmdSetSuccess)
 
 	return l.res.Set(req.Opaque, req.Quiet)
@@ -112,9 +113,10 @@ func (l *L1L2BatchOrca) Add(req common.SetRequest) error {
 			metrics.IncCounter(MetricCmdAddErrors)
 			return err
 		}
+	} else {
+		metrics.IncCounter(MetricCmdAddReplaceStoredL1)
 	}
 
-	metrics.IncCounter(MetricCmdAddReplaceStoredL1)
 	metrics.IncCounter(MetricCmdAddStored)
 
 	return l.res.Add(req.Opaque, req.Quiet)
@@ -159,9 +161,10 @@ func (l *L1L2BatchOrca) Replace(req common.SetRequest) error {
 			metrics.IncCounter(MetricCmdReplaceErrors)
 			return err
 		}
+	} else {
+		metrics.IncCounter(MetricCmdReplaceReplaceStoredL1)
 	}
 
-	metrics.IncCounter(MetricCmdReplaceReplaceStoredL1)
 	metrics.IncCounter(MetricCmdReplaceStored)
 
 	return l.res.Replace(req.Opaque, req.Quiet)

--- a/orcas/l1l2batch.go
+++ b/orcas/l1l2batch.go
@@ -50,26 +50,23 @@ func (l *L1L2BatchOrca) Set(req common.SetRequest) error {
 	}
 	metrics.IncCounter(MetricCmdSetSuccessL2)
 
-	// Invalidate the entry in L1 for batch sets.
-	delreq := common.DeleteRequest{
-		Key:    req.Key,
-		Opaque: req.Opaque,
-	}
-
-	metrics.IncCounter(MetricCmdSetDeleteL1)
-	if err := l.l1.Delete(delreq); err != nil {
+	// Replace the entry in L1.
+	req.Quiet = false
+	metrics.IncCounter(MetricCmdSetReplaceL1)
+	if err := l.l1.Replace(req); err != nil {
 		if err == common.ErrKeyNotFound {
-			// For a delete miss in L1, there's no problem.
-			// The state we want to exist is already in place.
-			metrics.IncCounter(MetricCmdSetDeleteMissesL1)
+			// For a replace not stored in L1, there's no problem.
+			// There is no hot data to replace
+			metrics.IncCounter(MetricCmdSetReplaceNotStoredL1)
 		} else {
-			metrics.IncCounter(MetricCmdSetDeleteErrorsL1)
+			metrics.IncCounter(MetricCmdSetReplaceErrorsL1)
 			metrics.IncCounter(MetricCmdSetErrors)
 			return err
 		}
 	}
 
-	metrics.IncCounter(MetricCmdSetDeleteSuccessL1)
+	metrics.IncCounter(MetricCmdSetReplaceStoredL1)
+	metrics.IncCounter(MetricCmdSetSuccess)
 
 	return l.res.Set(req.Opaque, req.Quiet)
 }
@@ -100,31 +97,22 @@ func (l *L1L2BatchOrca) Add(req common.SetRequest) error {
 
 	metrics.IncCounter(MetricCmdAddStoredL2)
 
-	// Invalidate the entry in L1 for batch adds. This might not make sense at
-	// first, but does in the context of concurrent requests. We want anything
-	// that is successfully added to the L2 to be gone from L1, regardless of
-	// what else is going on outside the current request. If a concurrent request
-	// completes between L2 and L1 in the non-batch endpoint, we still maintain
-	// correctness, albeit a bit slower.
-	delreq := common.DeleteRequest{
-		Key:    req.Key,
-		Opaque: req.Opaque,
-	}
-
-	metrics.IncCounter(MetricCmdAddDeleteL1)
-	if err := l.l1.Delete(delreq); err != nil {
+	// Replace the entry in L1.
+	req.Quiet = false
+	metrics.IncCounter(MetricCmdAddReplaceL1)
+	if err := l.l1.Replace(req); err != nil {
 		if err == common.ErrKeyNotFound {
-			// For a delete miss in L1, there's no problem.
-			// The state we want to exist is already in place.
-			metrics.IncCounter(MetricCmdAddDeleteMissesL1)
+			// For a replace not stored in L1, there's no problem.
+			// There is no hot data to replace
+			metrics.IncCounter(MetricCmdAddReplaceNotStoredL1)
 		} else {
-			metrics.IncCounter(MetricCmdAddDeleteErrorsL1)
+			metrics.IncCounter(MetricCmdAddReplaceErrorsL1)
 			metrics.IncCounter(MetricCmdAddErrors)
 			return err
 		}
 	}
 
-	metrics.IncCounter(MetricCmdAddDeleteSuccessL1)
+	metrics.IncCounter(MetricCmdAddReplaceStoredL1)
 	metrics.IncCounter(MetricCmdAddStored)
 
 	return l.res.Add(req.Opaque, req.Quiet)
@@ -156,26 +144,22 @@ func (l *L1L2BatchOrca) Replace(req common.SetRequest) error {
 
 	metrics.IncCounter(MetricCmdReplaceStoredL2)
 
-	// Invalidate the entry in L1 for batch replaces.
-	delreq := common.DeleteRequest{
-		Key:    req.Key,
-		Opaque: req.Opaque,
-	}
-
-	metrics.IncCounter(MetricCmdReplaceDeleteL1)
-	if err := l.l1.Delete(delreq); err != nil {
+	// Replace the entry in L1.
+	req.Quiet = false
+	metrics.IncCounter(MetricCmdReplaceReplaceL1)
+	if err := l.l1.Replace(req); err != nil {
 		if err == common.ErrKeyNotFound {
-			// For a delete miss in L1, there's no problem.
-			// The state we want to exist is already in place.
-			metrics.IncCounter(MetricCmdReplaceDeleteMissesL1)
+			// For a replace not stored in L1, there's no problem.
+			// There is no hot data to replace
+			metrics.IncCounter(MetricCmdReplaceReplaceNotStoredL1)
 		} else {
-			metrics.IncCounter(MetricCmdReplaceDeleteErrorsL1)
+			metrics.IncCounter(MetricCmdReplaceReplaceErrorsL1)
 			metrics.IncCounter(MetricCmdReplaceErrors)
 			return err
 		}
 	}
 
-	metrics.IncCounter(MetricCmdReplaceDeleteSuccessL1)
+	metrics.IncCounter(MetricCmdReplaceReplaceStoredL1)
 	metrics.IncCounter(MetricCmdReplaceStored)
 
 	return l.res.Replace(req.Opaque, req.Quiet)

--- a/orcas/types.go
+++ b/orcas/types.go
@@ -87,10 +87,10 @@ var (
 	MetricCmdSetErrorsL2  = metrics.AddCounter("cmd_set_errors_l2")
 
 	// Batch L1L2 set metrics
-	MetricCmdSetDeleteL1        = metrics.AddCounter("cmd_set_delete_l1")
-	MetricCmdSetDeleteMissesL1  = metrics.AddCounter("cmd_set_delete_misses_l1")
-	MetricCmdSetDeleteErrorsL1  = metrics.AddCounter("cmd_set_delete_errors_l1")
-	MetricCmdSetDeleteSuccessL1 = metrics.AddCounter("cmd_set_delete_success_l1")
+	MetricCmdSetReplaceL1          = metrics.AddCounter("cmd_set_replace_l1")
+	MetricCmdSetReplaceNotStoredL1 = metrics.AddCounter("cmd_set_replace_not_stored_l1")
+	MetricCmdSetReplaceErrorsL1    = metrics.AddCounter("cmd_set_replace_errors_l1")
+	MetricCmdSetReplaceStoredL1    = metrics.AddCounter("cmd_set_replace_stored_l1")
 
 	MetricCmdAdd            = metrics.AddCounter("cmd_add")
 	MetricCmdAddL1          = metrics.AddCounter("cmd_add_l1")
@@ -106,10 +106,10 @@ var (
 	MetricCmdAddErrorsL2    = metrics.AddCounter("cmd_add_errors_l2")
 
 	// Batch L1L2 add metrics
-	MetricCmdAddDeleteL1        = metrics.AddCounter("cmd_add_delete_l1")
-	MetricCmdAddDeleteMissesL1  = metrics.AddCounter("cmd_add_delete_misses_l1")
-	MetricCmdAddDeleteErrorsL1  = metrics.AddCounter("cmd_add_delete_errors_l1")
-	MetricCmdAddDeleteSuccessL1 = metrics.AddCounter("cmd_add_delete_success_l1")
+	MetricCmdAddReplaceL1          = metrics.AddCounter("cmd_add_replace_l1")
+	MetricCmdAddReplaceNotStoredL1 = metrics.AddCounter("cmd_add_replace_not_stored_l1")
+	MetricCmdAddReplaceErrorsL1    = metrics.AddCounter("cmd_add_replace_errors_l1")
+	MetricCmdAddReplaceStoredL1    = metrics.AddCounter("cmd_add_replace_stored_l1")
 
 	MetricCmdReplace            = metrics.AddCounter("cmd_replace")
 	MetricCmdReplaceL1          = metrics.AddCounter("cmd_replace_l1")
@@ -125,10 +125,10 @@ var (
 	MetricCmdReplaceErrorsL2    = metrics.AddCounter("cmd_replace_errors_l2")
 
 	// Batch L1L2 replace metrics
-	MetricCmdReplaceDeleteL1        = metrics.AddCounter("cmd_replace_delete_l1")
-	MetricCmdReplaceDeleteMissesL1  = metrics.AddCounter("cmd_replace_delete_misses_l1")
-	MetricCmdReplaceDeleteErrorsL1  = metrics.AddCounter("cmd_replace_delete_errors_l1")
-	MetricCmdReplaceDeleteSuccessL1 = metrics.AddCounter("cmd_replace_delete_success_l1")
+	MetricCmdReplaceReplaceL1          = metrics.AddCounter("cmd_replace_replace_l1")
+	MetricCmdReplaceReplaceNotStoredL1 = metrics.AddCounter("cmd_replace_replace_not_stored_l1")
+	MetricCmdReplaceReplaceErrorsL1    = metrics.AddCounter("cmd_replace_replace_errors_l1")
+	MetricCmdReplaceReplaceStoredL1    = metrics.AddCounter("cmd_replace_replace_stored_l1")
 
 	MetricCmdDelete         = metrics.AddCounter("cmd_delete")
 	MetricCmdDeleteL1       = metrics.AddCounter("cmd_delete_l1")

--- a/orcas/types.go
+++ b/orcas/types.go
@@ -157,10 +157,10 @@ var (
 	MetricCmdTouchErrorsL2 = metrics.AddCounter("cmd_touch_errors_l2")
 
 	// Batch L1L2 touch metrics
-	MetricCmdTouchDeleteL1        = metrics.AddCounter("cmd_touch_delete_l1")
-	MetricCmdTouchDeleteMissesL1  = metrics.AddCounter("cmd_touch_delete_misses_l1")
-	MetricCmdTouchDeleteErrorsL1  = metrics.AddCounter("cmd_touch_delete_errors_l1")
-	MetricCmdTouchDeleteSuccessL1 = metrics.AddCounter("cmd_touch_delete_success_l1")
+	MetricCmdTouchTouchL1       = metrics.AddCounter("cmd_touch_touch_l1")
+	MetricCmdTouchTouchMissesL1 = metrics.AddCounter("cmd_touch_touch_misses_l1")
+	MetricCmdTouchTouchErrorsL1 = metrics.AddCounter("cmd_touch_touch_errors_l1")
+	MetricCmdTouchTouchHitsL1   = metrics.AddCounter("cmd_touch_touch_hits_l1")
 
 	MetricCmdGat         = metrics.AddCounter("cmd_gat")
 	MetricCmdGatL1       = metrics.AddCounter("cmd_gat_l1")
@@ -185,11 +185,11 @@ var (
 	MetricCmdGatSetErrorsL2    = metrics.AddCounter("cmd_gat_set_errors_l2")
 	MetricCmdGatSetSuccessL2   = metrics.AddCounter("cmd_gat_set_success_l2")
 
-	// Batch L1L2 GAT metrics
-	MetricCmdGatDeleteL1        = metrics.AddCounter("cmd_gat_delete_l1")
-	MetricCmdGatDeleteMissesL1  = metrics.AddCounter("cmd_gat_delete_misses_l1")
-	MetricCmdGatDeleteErrorsL1  = metrics.AddCounter("cmd_gat_delete_errors_l1")
-	MetricCmdGatDeleteSuccessL1 = metrics.AddCounter("cmd_gat_delete_success_l1")
+	// Batch L1L2 gat metrics
+	MetricCmdGatTouchL1       = metrics.AddCounter("cmd_gat_touch_l1")
+	MetricCmdGatTouchMissesL1 = metrics.AddCounter("cmd_gat_touch_misses_l1")
+	MetricCmdGatTouchErrorsL1 = metrics.AddCounter("cmd_gat_touch_errors_l1")
+	MetricCmdGatTouchHitsL1   = metrics.AddCounter("cmd_gat_touch_hits_l1")
 
 	MetricCmdUnknown = metrics.AddCounter("cmd_unknown")
 	MetricCmdNoop    = metrics.AddCounter("cmd_noop")


### PR DESCRIPTION
This tweaks the behavior of the L1/L2 batch orchestrator to more actively manage the hot data in L1 vs. deleting on any change. This keeps hot data hot even if it is changed out from under the member watching Netflix at the time. Large batch computes would otherwise cause all hot data to be evicted from L1 anyway, which was the point of having a different port and orchestrator to begin with. 

Closes #74 

CC @vuzilla @senugula @smadappa @akpratt for review