### PR TITLE
metric counter init to -1 causing unreported metrics and index out of…

### DIFF
--- a/metrics/callbackgauges.go
+++ b/metrics/callbackgauges.go
@@ -17,15 +17,14 @@ var (
 )
 
 func init() {
-	// start with "-1" so the first metric ID overflows to 0
-	atomic.StoreUint32(curIntCbID, 0xFFFFFFFF)
-	atomic.StoreUint32(curFloatCbID, 0xFFFFFFFF)
+	atomic.StoreUint32(curIntCbID, 0)
+	atomic.StoreUint32(curFloatCbID, 0)
 }
 
 // Registers a gauge callback which will be called every time metrics are requested.
 // There is a maximum of 1024 callbacks, after which adding a new one will panic
 func RegisterIntGaugeCallback(name string, cb IntGaugeCallback) {
-	id := atomic.AddUint32(curIntCbID, 1)
+	id := atomic.AddUint32(curIntCbID, 1) - 1
 
 	if id >= maxNumCallbacks {
 		panic("Too many callbacks")
@@ -38,7 +37,7 @@ func RegisterIntGaugeCallback(name string, cb IntGaugeCallback) {
 // Registers a gauge callback which will be called every time metrics are requested.
 // There is a maximum of 1024 callbacks, after which adding a new one will panic
 func RegisterFloatGaugeCallback(name string, cb FloatGaugeCallback) {
-	id := atomic.AddUint32(curFloatCbID, 1)
+	id := atomic.AddUint32(curFloatCbID, 1) - 1
 
 	if id >= maxNumCallbacks {
 		panic("Too many callbacks")

--- a/metrics/counters.go
+++ b/metrics/counters.go
@@ -26,13 +26,13 @@ var (
 
 func init() {
 	// start with "-1" so the first metric ID overflows to 0
-	atomic.StoreUint32(curCounterID, 0xFFFFFFFF)
+	atomic.StoreUint32(curCounterID, 0)
 }
 
 // Registers a counter and returns an ID that can be used to access it
 // There is a maximum of 1024 metrics, after which adding a new one will panic
 func AddCounter(name string) uint32 {
-	id := atomic.AddUint32(curCounterID, 1)
+	id := atomic.AddUint32(curCounterID, 1) - 1
 
 	if id >= maxNumCounters {
 		panic("Too many counters")

--- a/metrics/gauges.go
+++ b/metrics/gauges.go
@@ -17,15 +17,14 @@ var (
 )
 
 func init() {
-	// start with "-1" so the first metric ID overflows to 0
-	atomic.StoreUint32(curIntGaugeID, 0xFFFFFFFF)
-	atomic.StoreUint32(curFloatGaugeID, 0xFFFFFFFF)
+	atomic.StoreUint32(curIntGaugeID, 0)
+	atomic.StoreUint32(curFloatGaugeID, 0)
 }
 
 // Registers a gauge and returns an ID that can be used to access it
 // There is a maximum of 1024 gauges, after which adding a new one will panic
 func AddIntGauge(name string) uint32 {
-	id := atomic.AddUint32(curIntGaugeID, 1)
+	id := atomic.AddUint32(curIntGaugeID, 1) - 1
 
 	if id >= maxNumGauges {
 		panic("Too many gauges")
@@ -38,7 +37,7 @@ func AddIntGauge(name string) uint32 {
 // Registers a gauge and returns an ID that can be used to access it
 // There is a maximum of 1024 gauges, after which adding a new one will panic
 func AddFloatGauge(name string) uint32 {
-	id := atomic.AddUint32(curFloatGaugeID, 1)
+	id := atomic.AddUint32(curFloatGaugeID, 1) - 1
 
 	if id >= maxNumGauges {
 		panic("Too many gauges")

--- a/metrics/histograms.go
+++ b/metrics/histograms.go
@@ -35,7 +35,7 @@ var (
 
 func init() {
 	// start at "-1" so the first ID is 0
-	atomic.StoreUint32(curHistID, 0xFFFFFFFF)
+	atomic.StoreUint32(curHistID, 0)
 }
 
 // The hist struct holds a primary and secondary data structure so the reader of
@@ -83,7 +83,7 @@ func newBHist() *bhist {
 }
 
 func AddHistogram(name string, sampled bool) uint32 {
-	idx := atomic.AddUint32(curHistID, 1)
+	idx := atomic.AddUint32(curHistID, 1) - 1
 
 	if idx >= maxNumHists {
 		panic("Too many histograms")


### PR DESCRIPTION
starting the index at -1 causes issues:
- unreported metrics because we can't get the last metric
- index out of range error when we don't create any metric of that type (gauge in this case)
