### PR TITLE
Changing standard port GAT to touch L2 on L1 GAT hit instead of set

### DIFF
--- a/orcas/l1l2.go
+++ b/orcas/l1l2.go
@@ -705,6 +705,7 @@ func (l *L1L2Orca) Gat(req common.GATRequest) error {
 			if err == common.ErrKeyNotFound {
 				// this is a problem. L1 had the item but L2 doesn't. To avoid an
 				// inconsistent view, return the same ErrNotFound and fail the op.
+				metrics.IncCounter(MetricInconsistencyDetected)
 				metrics.IncCounter(MetricCmdGatTouchMissesL2)
 				metrics.IncCounter(MetricCmdGatMisses)
 			} else {

--- a/orcas/types.go
+++ b/orcas/types.go
@@ -209,4 +209,7 @@ var (
 	MetricCmdGatTouchMissesL1 = metrics.AddCounter("cmd_gat_touch_misses_l1")
 	MetricCmdGatTouchErrorsL1 = metrics.AddCounter("cmd_gat_touch_errors_l1")
 	MetricCmdGatTouchHitsL1   = metrics.AddCounter("cmd_gat_touch_hits_l1")
+
+	// Special metrics
+	MetricInconsistencyDetected = metrics.AddCounter("inconsistency_detected")
 )

--- a/orcas/types.go
+++ b/orcas/types.go
@@ -199,9 +199,10 @@ var (
 	MetricCmdGatAddErrorsL1    = metrics.AddCounter("cmd_gat_add_errors_l1")
 	MetricCmdGatAddStoredL1    = metrics.AddCounter("cmd_gat_add_stored_l1")
 	MetricCmdGatAddNotStoredL1 = metrics.AddCounter("cmd_gat_add_not_stored_l1")
-	MetricCmdGatSetL2          = metrics.AddCounter("cmd_gat_set_l2")
-	MetricCmdGatSetErrorsL2    = metrics.AddCounter("cmd_gat_set_errors_l2")
-	MetricCmdGatSetSuccessL2   = metrics.AddCounter("cmd_gat_set_success_l2")
+	MetricCmdGatTouchL2        = metrics.AddCounter("cmd_gat_touch_l2")
+	MetricCmdGatTouchHitsL2    = metrics.AddCounter("cmd_gat_touch_hits_l2")
+	MetricCmdGatTouchMissesL2  = metrics.AddCounter("cmd_gat_touch_misses_l2")
+	MetricCmdGatTouchErrorsL2  = metrics.AddCounter("cmd_gat_touch_errors_l2")
 
 	// Batch L1L2 gat metrics
 	MetricCmdGatTouchL1       = metrics.AddCounter("cmd_gat_touch_l1")


### PR DESCRIPTION
This is a change to help internal transitions and deployments. It allows L2 to have more control over what it wants to do with the touches. It does require L2 to do more disk reads in the standard scenario, but this is acceptable for our use cases.

CC @vuzilla @smadappa @senugula @akpratt 