### PR TITLE
Sub op histograms

### DIFF
--- a/metrics/endpoint.go
+++ b/metrics/endpoint.go
@@ -125,7 +125,7 @@ func printMetrics(w http.ResponseWriter, r *http.Request) {
 	bhists := getAllBucketHistograms()
 	for name, bh := range bhists {
 		var bmax uint64 = math.MaxUint64 // 0xFFFF_FFFF_FFFF_FFFF
-		for i := 0; i < 64; i++ {
+		for i := 0; i < bhistlen; i++ {
 			fmt.Fprintf(w, "%sbhist_%s_bucket_%d %d\n", prefix, name, bmax, bh[i])
 			bmax >>= 1
 		}

--- a/metrics/histograms.go
+++ b/metrics/histograms.go
@@ -23,6 +23,7 @@ import (
 const (
 	maxNumHists = 1024
 	buflen      = 0x7FFF // max index, 32769 entries
+	bhistlen    = 65
 )
 
 var (
@@ -78,7 +79,7 @@ type bhist struct {
 func newBHist() *bhist {
 	return &bhist{
 		// Holds enough for the entire length of a uint64
-		buckets: make([]uint64, 64),
+		buckets: make([]uint64, 65),
 	}
 }
 
@@ -189,8 +190,8 @@ func getAllBucketHistograms() map[string][]uint64 {
 }
 
 func extractBHist(b *bhist) []uint64 {
-	ret := make([]uint64, 64)
-	for i := 0; i < 64; i++ {
+	ret := make([]uint64, bhistlen)
+	for i := 0; i < bhistlen; i++ {
 		ret[i] = atomic.LoadUint64(&b.buckets[i])
 	}
 	return ret

--- a/orcas/l1l2.go
+++ b/orcas/l1l2.go
@@ -15,6 +15,8 @@
 package orcas
 
 import (
+	"time"
+
 	"github.com/netflix/rend/common"
 	"github.com/netflix/rend/handlers"
 	"github.com/netflix/rend/metrics"
@@ -39,7 +41,10 @@ func (l *L1L2Orca) Set(req common.SetRequest) error {
 
 	// Try L2 first
 	metrics.IncCounter(MetricCmdSetL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Set(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistSetL2, uint64(dur))
 
 	// If we fail to set in L2, don't set in L1
 	if err != nil {
@@ -65,7 +70,12 @@ func (l *L1L2Orca) Set(req common.SetRequest) error {
 	// connections to everyone will be severed (for this one client connection)
 	// and that the client will reconnect to try again.
 	metrics.IncCounter(MetricCmdSetL1)
-	if err := l.l1.Set(req); err != nil {
+	start = time.Now().UnixNano()
+	err = l.l1.Set(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistSetL1, uint64(dur))
+
+	if err != nil {
 		metrics.IncCounter(MetricCmdSetErrorsL1)
 		metrics.IncCounter(MetricCmdSetErrors)
 		return err
@@ -82,7 +92,10 @@ func (l *L1L2Orca) Add(req common.SetRequest) error {
 
 	// Add in L2 first, since it has the larger state
 	metrics.IncCounter(MetricCmdAddL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Add(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistAddL2, uint64(dur))
 
 	if err != nil {
 		// A key already existing is not an error per se, it's a part of the
@@ -112,7 +125,10 @@ func (l *L1L2Orca) Add(req common.SetRequest) error {
 	// L1 between the two add operations, causing the L2 to be deleted and
 	// the L1 to have the data.
 	metrics.IncCounter(MetricCmdAddL1)
+	start = time.Now().UnixNano()
 	err = l.l1.Add(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistAddL1, uint64(dur))
 
 	if err != nil {
 		// This is kind of a problem. What has happened here is that the L2
@@ -147,7 +163,10 @@ func (l *L1L2Orca) Replace(req common.SetRequest) error {
 
 	// Replace in L2 first, since it has the larger state
 	metrics.IncCounter(MetricCmdReplaceL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Replace(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistReplaceL2, uint64(dur))
 
 	if err != nil {
 		// A key not existing is not an error per se, it's a part of the
@@ -185,7 +204,10 @@ func (l *L1L2Orca) Replace(req common.SetRequest) error {
 	// The other risk here is a concurrent replace for the same key, which will
 	// possibly interleave to produce inconsistency in L2 and L1.
 	metrics.IncCounter(MetricCmdReplaceL1)
+	start = time.Now().UnixNano()
 	err = l.l1.Replace(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistReplaceL1, uint64(dur))
 
 	if err != nil {
 		// In this case, the replace worked fine, and we don't worry about it not
@@ -225,7 +247,10 @@ func (l *L1L2Orca) Append(req common.SetRequest) error {
 	// commonly happens.
 
 	metrics.IncCounter(MetricCmdAppendL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Append(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistAppendL2, uint64(dur))
 
 	if err != nil {
 		// Appending in L2 did not succeed. Don't try in L1 since this means L2
@@ -246,7 +271,11 @@ func (l *L1L2Orca) Append(req common.SetRequest) error {
 	// there's an error, we need to fail because we're not in an unknown state
 	// where L1 possibly doesn't have the append when L2 does. We don't recover
 	// from this but instead fail the request and let the client retry.
+	metrics.IncCounter(MetricCmdAppendL1)
+	start = time.Now().UnixNano()
 	err = l.l1.Append(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistAppendL1, uint64(dur))
 
 	if err != nil {
 		// Not stored in L1 is still fine. There's a possibility that a
@@ -273,7 +302,10 @@ func (l *L1L2Orca) Prepend(req common.SetRequest) error {
 	//log.Println("prepend", string(req.Key))
 
 	metrics.IncCounter(MetricCmdPrependL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Prepend(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistPrependL2, uint64(dur))
 
 	if err != nil {
 		// Prepending in L2 did not succeed. Don't try in L1 since this means L2
@@ -294,7 +326,11 @@ func (l *L1L2Orca) Prepend(req common.SetRequest) error {
 	// there's an error, we need to fail because we're not in an unknown state
 	// where L1 possibly doesn't have the Prepend when L2 does. We don't recover
 	// from this but instead fail the request and let the client retry.
+	metrics.IncCounter(MetricCmdPrependL1)
+	start = time.Now().UnixNano()
 	err = l.l1.Prepend(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistPrependL1, uint64(dur))
 
 	if err != nil {
 		// Not stored in L1 is still fine. There's a possibility that a
@@ -322,7 +358,10 @@ func (l *L1L2Orca) Delete(req common.DeleteRequest) error {
 
 	// Try L2 first
 	metrics.IncCounter(MetricCmdDeleteL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Delete(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistDeleteL2, uint64(dur))
 
 	if err != nil {
 		// On a delete miss in L2 don't bother deleting in L1. There might be no
@@ -352,7 +391,12 @@ func (l *L1L2Orca) Delete(req common.DeleteRequest) error {
 	// L2, set in L1, then deleted in L2. By deleting from L2 first, if L1 goes
 	// missing then no other request can undo part of this request.
 	metrics.IncCounter(MetricCmdDeleteL1)
-	if err := l.l1.Delete(req); err != nil {
+	start = time.Now().UnixNano()
+	err = l.l1.Delete(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistDeleteL1, uint64(dur))
+
+	if err != nil {
 		// Delete misses in L1 are fine. If we get here, that means the delete
 		// in L2 hit. This isn't a miss per se since the overall effect is a
 		// delete. Concurrent deletes might interleave to produce this, or the
@@ -379,7 +423,10 @@ func (l *L1L2Orca) Touch(req common.TouchRequest) error {
 
 	// Try L2 first
 	metrics.IncCounter(MetricCmdTouchL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Touch(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistTouchL2, uint64(dur))
 
 	if err != nil {
 		// On a touch miss in L2 don't bother touch in L1. The data should be
@@ -409,7 +456,12 @@ func (l *L1L2Orca) Touch(req common.TouchRequest) error {
 	// another request, then L1 touched long. In this case the data in L1 would
 	// outlive L2. This situation is uncommon and is therefore discounted.
 	metrics.IncCounter(MetricCmdTouchL1)
-	if err := l.l1.Touch(req); err != nil {
+	start = time.Now().UnixNano()
+	err = l.l1.Touch(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistTouchL1, uint64(dur))
+
+	if err != nil {
 		// Touch misses in L1 after a hit in L2 are nto a big deal. The
 		// touch operation here explicitly does *not* act as a pre-warm putting
 		// data into L1. A miss here after a hit is the same as a hit.
@@ -443,6 +495,7 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 
 	metrics.IncCounter(MetricCmdGetL1)
 	metrics.IncCounterBy(MetricCmdGetKeysL1, uint64(len(req.Keys)))
+	start := time.Now().UnixNano()
 	resChan, errChan := l.l1.Get(req)
 
 	var err error
@@ -489,6 +542,10 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 		}
 	}
 
+	// finish up metrics for overall L1 (batch) get operation
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistGetL1, uint64(dur))
+
 	// leave early on all hits
 	if len(l2keys) == 0 {
 		if err != nil {
@@ -508,6 +565,7 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 
 	metrics.IncCounter(MetricCmdGetEL2)
 	metrics.IncCounterBy(MetricCmdGetEKeysL2, uint64(len(l2keys)))
+	start = time.Now().UnixNano()
 	resChanE, errChan := l.l2.GetE(req)
 	for {
 		select {
@@ -523,7 +581,6 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 					metrics.IncCounter(MetricCmdGetEHitsL2)
 
 					//set in l1
-					metrics.IncCounter(MetricCmdGetSetL1)
 					setreq := common.SetRequest{
 						Key:     res.Key,
 						Flags:   res.Flags,
@@ -531,7 +588,11 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 						Data:    res.Data,
 					}
 
-					if err := l.l1.Set(setreq); err != nil {
+					metrics.IncCounter(MetricCmdGetSetL1)
+					start = time.Now().UnixNano()
+					err = l.l1.Set(setreq)
+
+					if err != nil {
 						metrics.IncCounter(MetricCmdGetSetErrorsL1)
 						return err
 					}
@@ -569,6 +630,10 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 		}
 	}
 
+	// finish up metrics for overall L2 (batch) get operation
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistGetL2, uint64(dur))
+
 	if err == nil {
 		return l.res.GetEnd(req.NoopOpaque, req.NoopEnd)
 	}
@@ -584,9 +649,12 @@ func (l *L1L2Orca) GetE(req common.GetRequest) error {
 func (l *L1L2Orca) Gat(req common.GATRequest) error {
 	//log.Println("gat", string(req.Key))
 
-	// Try L1 first, since it'll be faster if it succeeds
+	// Try L1 first
 	metrics.IncCounter(MetricCmdGatL1)
+	start := time.Now().UnixNano()
 	res, err := l.l1.GAT(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistGatL1, uint64(dur))
 
 	// Errors here are genrally fatal to the connection, as something has gone
 	// seriously wrong. Bail out early.
@@ -608,7 +676,10 @@ func (l *L1L2Orca) Gat(req common.GATRequest) error {
 		metrics.IncCounter(MetricCmdGatMissesL1)
 
 		metrics.IncCounter(MetricCmdGatL2)
+		start = time.Now().UnixNano()
 		res, err = l.l2.GAT(req)
+		dur = time.Now().UnixNano() - start
+		metrics.ObserveHist(HistGatL2, uint64(dur))
 
 		// fatal error
 		if err != nil {
@@ -644,7 +715,12 @@ func (l *L1L2Orca) Gat(req common.GATRequest) error {
 		}
 
 		metrics.IncCounter(MetricCmdGatAddL1)
-		if err := l.l1.Add(setreq); err != nil {
+		start = time.Now().UnixNano()
+		err = l.l1.Add(setreq)
+		dur := time.Now().UnixNano() - start
+		metrics.ObserveHist(HistAddL1, uint64(dur))
+
+		if err != nil {
 			// we were trampled in the middle of performing the GAT operation
 			// In this case, it's fine; no error for the overall op. We still
 			// want to track this with a metric, though, and return success.
@@ -699,7 +775,10 @@ func (l *L1L2Orca) Gat(req common.GATRequest) error {
 		}
 
 		metrics.IncCounter(MetricCmdGatSetL2)
+		start = time.Now().UnixNano()
 		err := l.l2.Set(setreq)
+		dur := time.Now().UnixNano() - start
+		metrics.ObserveHist(HistSetL2, uint64(dur))
 
 		if err != nil {
 			// set error? Return it as our error. Yes, the GAT succeeded in L1

--- a/orcas/l1l2.go
+++ b/orcas/l1l2.go
@@ -622,7 +622,11 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 
 					metrics.IncCounter(MetricCmdGetSetL1)
 					start = time.Now().UnixNano()
+
 					err = l.l1.Set(setreq)
+
+					dur = time.Now().UnixNano() - start
+					metrics.ObserveHist(HistSetL1, uint64(dur))
 
 					if err != nil {
 						metrics.IncCounter(MetricCmdGetSetErrorsL1)

--- a/orcas/l1l2.go
+++ b/orcas/l1l2.go
@@ -43,7 +43,9 @@ func (l *L1L2Orca) Set(req common.SetRequest) error {
 	// Try L2 first
 	metrics.IncCounter(MetricCmdSetL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Set(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistSetL2, uint64(dur))
 
@@ -72,7 +74,9 @@ func (l *L1L2Orca) Set(req common.SetRequest) error {
 	// and that the client will reconnect to try again.
 	metrics.IncCounter(MetricCmdSetL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Set(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistSetL1, uint64(dur))
 
@@ -94,7 +98,9 @@ func (l *L1L2Orca) Add(req common.SetRequest) error {
 	// Add in L2 first, since it has the larger state
 	metrics.IncCounter(MetricCmdAddL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Add(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistAddL2, uint64(dur))
 
@@ -127,7 +133,9 @@ func (l *L1L2Orca) Add(req common.SetRequest) error {
 	// the L1 to have the data.
 	metrics.IncCounter(MetricCmdAddL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Add(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistAddL1, uint64(dur))
 
@@ -165,7 +173,9 @@ func (l *L1L2Orca) Replace(req common.SetRequest) error {
 	// Replace in L2 first, since it has the larger state
 	metrics.IncCounter(MetricCmdReplaceL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Replace(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistReplaceL2, uint64(dur))
 
@@ -206,7 +216,9 @@ func (l *L1L2Orca) Replace(req common.SetRequest) error {
 	// possibly interleave to produce inconsistency in L2 and L1.
 	metrics.IncCounter(MetricCmdReplaceL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Replace(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistReplaceL1, uint64(dur))
 
@@ -249,7 +261,9 @@ func (l *L1L2Orca) Append(req common.SetRequest) error {
 
 	metrics.IncCounter(MetricCmdAppendL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Append(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistAppendL2, uint64(dur))
 
@@ -274,7 +288,9 @@ func (l *L1L2Orca) Append(req common.SetRequest) error {
 	// from this but instead fail the request and let the client retry.
 	metrics.IncCounter(MetricCmdAppendL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Append(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistAppendL1, uint64(dur))
 
@@ -304,7 +320,9 @@ func (l *L1L2Orca) Prepend(req common.SetRequest) error {
 
 	metrics.IncCounter(MetricCmdPrependL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Prepend(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistPrependL2, uint64(dur))
 
@@ -329,7 +347,9 @@ func (l *L1L2Orca) Prepend(req common.SetRequest) error {
 	// from this but instead fail the request and let the client retry.
 	metrics.IncCounter(MetricCmdPrependL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Prepend(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistPrependL1, uint64(dur))
 
@@ -360,7 +380,9 @@ func (l *L1L2Orca) Delete(req common.DeleteRequest) error {
 	// Try L2 first
 	metrics.IncCounter(MetricCmdDeleteL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Delete(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistDeleteL2, uint64(dur))
 
@@ -393,7 +415,9 @@ func (l *L1L2Orca) Delete(req common.DeleteRequest) error {
 	// missing then no other request can undo part of this request.
 	metrics.IncCounter(MetricCmdDeleteL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Delete(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistDeleteL1, uint64(dur))
 
@@ -425,7 +449,9 @@ func (l *L1L2Orca) Touch(req common.TouchRequest) error {
 	// Try L2 first
 	metrics.IncCounter(MetricCmdTouchL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Touch(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistTouchL2, uint64(dur))
 
@@ -458,7 +484,9 @@ func (l *L1L2Orca) Touch(req common.TouchRequest) error {
 	// outlive L2. This situation is uncommon and is therefore discounted.
 	metrics.IncCounter(MetricCmdTouchL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Touch(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistTouchL1, uint64(dur))
 
@@ -497,6 +525,7 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 	metrics.IncCounter(MetricCmdGetL1)
 	metrics.IncCounterBy(MetricCmdGetKeysL1, uint64(len(req.Keys)))
 	start := time.Now().UnixNano()
+
 	resChan, errChan := l.l1.Get(req)
 
 	var err error
@@ -567,7 +596,9 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 	metrics.IncCounter(MetricCmdGetEL2)
 	metrics.IncCounterBy(MetricCmdGetEKeysL2, uint64(len(l2keys)))
 	start = time.Now().UnixNano()
+
 	resChanE, errChan := l.l2.GetE(req)
+
 	for {
 		select {
 		case res, ok := <-resChanE:
@@ -654,7 +685,9 @@ func (l *L1L2Orca) Gat(req common.GATRequest) error {
 	// Try L1 first
 	metrics.IncCounter(MetricCmdGatL1)
 	start := time.Now().UnixNano()
+
 	res, err := l.l1.GAT(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistGatL1, uint64(dur))
 
@@ -679,7 +712,9 @@ func (l *L1L2Orca) Gat(req common.GATRequest) error {
 
 		metrics.IncCounter(MetricCmdGatL2)
 		start = time.Now().UnixNano()
+
 		res, err = l.l2.GAT(req)
+
 		dur = time.Now().UnixNano() - start
 		metrics.ObserveHist(HistGatL2, uint64(dur))
 
@@ -718,7 +753,9 @@ func (l *L1L2Orca) Gat(req common.GATRequest) error {
 
 		metrics.IncCounter(MetricCmdGatAddL1)
 		start = time.Now().UnixNano()
+
 		err = l.l1.Add(setreq)
+
 		dur := time.Now().UnixNano() - start
 		metrics.ObserveHist(HistAddL1, uint64(dur))
 
@@ -778,7 +815,9 @@ func (l *L1L2Orca) Gat(req common.GATRequest) error {
 
 		metrics.IncCounter(MetricCmdGatSetL2)
 		start = time.Now().UnixNano()
+
 		err := l.l2.Set(setreq)
+
 		dur := time.Now().UnixNano() - start
 		metrics.ObserveHist(HistSetL2, uint64(dur))
 

--- a/orcas/l1l2.go
+++ b/orcas/l1l2.go
@@ -15,6 +15,7 @@
 package orcas
 
 import (
+	"log"
 	"time"
 
 	"github.com/netflix/rend/common"
@@ -643,6 +644,7 @@ func (l *L1L2Orca) Get(req common.GetRequest) error {
 
 func (l *L1L2Orca) GetE(req common.GetRequest) error {
 	// The L1/L2 does not support getE, only L1Only does.
+	log.Println("[WARN] Use of GetE in L1L2 Batch orchestrator")
 	return common.ErrUnknownCmd
 }
 

--- a/orcas/l1l2batch.go
+++ b/orcas/l1l2batch.go
@@ -43,7 +43,9 @@ func (l *L1L2BatchOrca) Set(req common.SetRequest) error {
 	// Try L2 first
 	metrics.IncCounter(MetricCmdSetL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Set(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistSetL2, uint64(dur))
 
@@ -59,7 +61,9 @@ func (l *L1L2BatchOrca) Set(req common.SetRequest) error {
 	req.Quiet = false
 	metrics.IncCounter(MetricCmdSetReplaceL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Replace(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistReplaceL1, uint64(dur))
 
@@ -88,7 +92,9 @@ func (l *L1L2BatchOrca) Add(req common.SetRequest) error {
 	// Add in L2 first, since it has the larger state
 	metrics.IncCounter(MetricCmdAddL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Add(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistAddL2, uint64(dur))
 
@@ -114,7 +120,9 @@ func (l *L1L2BatchOrca) Add(req common.SetRequest) error {
 	req.Quiet = false
 	metrics.IncCounter(MetricCmdAddReplaceL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Replace(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistReplaceL1, uint64(dur))
 
@@ -143,7 +151,9 @@ func (l *L1L2BatchOrca) Replace(req common.SetRequest) error {
 	// Add in L2 first, since it has the larger state
 	metrics.IncCounter(MetricCmdReplaceL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Replace(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistReplaceL2, uint64(dur))
 
@@ -169,7 +179,9 @@ func (l *L1L2BatchOrca) Replace(req common.SetRequest) error {
 	req.Quiet = false
 	metrics.IncCounter(MetricCmdReplaceReplaceL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Replace(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistReplaceL1, uint64(dur))
 
@@ -207,7 +219,9 @@ func (l *L1L2BatchOrca) Append(req common.SetRequest) error {
 	// commonly happens.
 	metrics.IncCounter(MetricCmdAppendL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Append(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistAppendL2, uint64(dur))
 
@@ -232,7 +246,9 @@ func (l *L1L2BatchOrca) Append(req common.SetRequest) error {
 	// from this but instead fail the request and let the client retry.
 	metrics.IncCounter(MetricCmdAppendL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Append(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistAppendL1, uint64(dur))
 
@@ -262,7 +278,9 @@ func (l *L1L2BatchOrca) Prepend(req common.SetRequest) error {
 
 	metrics.IncCounter(MetricCmdPrependL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Prepend(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistPrependL2, uint64(dur))
 
@@ -287,7 +305,9 @@ func (l *L1L2BatchOrca) Prepend(req common.SetRequest) error {
 	// from this but instead fail the request and let the client retry.
 	metrics.IncCounter(MetricCmdPrependL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Prepend(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistPrependL1, uint64(dur))
 
@@ -318,7 +338,9 @@ func (l *L1L2BatchOrca) Delete(req common.DeleteRequest) error {
 	// Try L2 first
 	metrics.IncCounter(MetricCmdDeleteL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Delete(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistDeleteL2, uint64(dur))
 
@@ -351,7 +373,9 @@ func (l *L1L2BatchOrca) Delete(req common.DeleteRequest) error {
 	// missing then no other request can undo part of this request.
 	metrics.IncCounter(MetricCmdDeleteL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Delete(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistDeleteL1, uint64(dur))
 
@@ -383,7 +407,9 @@ func (l *L1L2BatchOrca) Touch(req common.TouchRequest) error {
 	// Try L2 first
 	metrics.IncCounter(MetricCmdTouchL2)
 	start := time.Now().UnixNano()
+
 	err := l.l2.Touch(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistTouchL2, uint64(dur))
 
@@ -416,7 +442,9 @@ func (l *L1L2BatchOrca) Touch(req common.TouchRequest) error {
 	// more disruptive.
 	metrics.IncCounter(MetricCmdTouchTouchL1)
 	start = time.Now().UnixNano()
+
 	err = l.l1.Touch(req)
+
 	dur = time.Now().UnixNano() - start
 	metrics.ObserveHist(HistTouchL1, uint64(dur))
 
@@ -450,6 +478,7 @@ func (l *L1L2BatchOrca) Get(req common.GetRequest) error {
 	metrics.IncCounter(MetricCmdGetL1)
 	metrics.IncCounterBy(MetricCmdGetKeysL1, uint64(len(req.Keys)))
 	start := time.Now().UnixNano()
+
 	resChan, errChan := l.l1.Get(req)
 
 	var err error
@@ -520,7 +549,9 @@ func (l *L1L2BatchOrca) Get(req common.GetRequest) error {
 	metrics.IncCounter(MetricCmdGetL2)
 	metrics.IncCounterBy(MetricCmdGetKeysL2, uint64(len(l2keys)))
 	start = time.Now().UnixNano()
+
 	resChan, errChan = l.l2.Get(req)
+
 	for {
 		select {
 		case res, ok := <-resChan:
@@ -592,7 +623,9 @@ func (l *L1L2BatchOrca) Gat(req common.GATRequest) error {
 	// Perform L2 for correctness, invalidate in L1 later
 	metrics.IncCounter(MetricCmdGatL2)
 	start := time.Now().UnixNano()
+
 	res, err := l.l2.GAT(req)
+
 	dur := time.Now().UnixNano() - start
 	metrics.ObserveHist(HistGatL2, uint64(dur))
 
@@ -629,7 +662,9 @@ func (l *L1L2BatchOrca) Gat(req common.GATRequest) error {
 		// Try touching in L1 to touch hot data. See touch impl for reasoning.
 		metrics.IncCounter(MetricCmdGatTouchL1)
 		start = time.Now().UnixNano()
+
 		err = l.l1.Touch(touchreq)
+
 		dur = time.Now().UnixNano() - start
 		metrics.ObserveHist(HistTouchL1, uint64(dur))
 

--- a/orcas/l1l2batch.go
+++ b/orcas/l1l2batch.go
@@ -16,6 +16,7 @@ package orcas
 
 import (
 	"log"
+	"time"
 
 	"github.com/netflix/rend/common"
 	"github.com/netflix/rend/handlers"
@@ -41,7 +42,10 @@ func (l *L1L2BatchOrca) Set(req common.SetRequest) error {
 
 	// Try L2 first
 	metrics.IncCounter(MetricCmdSetL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Set(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistSetL2, uint64(dur))
 
 	// If we fail to set in L2, don't do anything in L1
 	if err != nil {
@@ -54,7 +58,12 @@ func (l *L1L2BatchOrca) Set(req common.SetRequest) error {
 	// Replace the entry in L1.
 	req.Quiet = false
 	metrics.IncCounter(MetricCmdSetReplaceL1)
-	if err := l.l1.Replace(req); err != nil {
+	start = time.Now().UnixNano()
+	err = l.l1.Replace(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistReplaceL1, uint64(dur))
+
+	if err != nil {
 		if err == common.ErrKeyNotFound {
 			// For a replace not stored in L1, there's no problem.
 			// There is no hot data to replace
@@ -78,7 +87,10 @@ func (l *L1L2BatchOrca) Add(req common.SetRequest) error {
 
 	// Add in L2 first, since it has the larger state
 	metrics.IncCounter(MetricCmdAddL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Add(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistAddL2, uint64(dur))
 
 	if err != nil {
 		// A key already existing is not an error per se, it's a part of the
@@ -101,7 +113,12 @@ func (l *L1L2BatchOrca) Add(req common.SetRequest) error {
 	// Replace the entry in L1.
 	req.Quiet = false
 	metrics.IncCounter(MetricCmdAddReplaceL1)
-	if err := l.l1.Replace(req); err != nil {
+	start = time.Now().UnixNano()
+	err = l.l1.Replace(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistReplaceL1, uint64(dur))
+
+	if err != nil {
 		if err == common.ErrKeyNotFound {
 			// For a replace not stored in L1, there's no problem.
 			// There is no hot data to replace
@@ -125,7 +142,10 @@ func (l *L1L2BatchOrca) Replace(req common.SetRequest) error {
 
 	// Add in L2 first, since it has the larger state
 	metrics.IncCounter(MetricCmdReplaceL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Replace(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistReplaceL2, uint64(dur))
 
 	if err != nil {
 		// A key already existing is not an error per se, it's a part of the
@@ -148,7 +168,12 @@ func (l *L1L2BatchOrca) Replace(req common.SetRequest) error {
 	// Replace the entry in L1.
 	req.Quiet = false
 	metrics.IncCounter(MetricCmdReplaceReplaceL1)
-	if err := l.l1.Replace(req); err != nil {
+	start = time.Now().UnixNano()
+	err = l.l1.Replace(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistReplaceL1, uint64(dur))
+
+	if err != nil {
 		if err == common.ErrKeyNotFound {
 			// For a replace not stored in L1, there's no problem.
 			// There is no hot data to replace
@@ -180,9 +205,11 @@ func (l *L1L2BatchOrca) Append(req common.SetRequest) error {
 	// completes both L2 and L1 between the L2 and L1 of this operation. This is
 	// an accepted risk which can be solved by the locking wrapper if it
 	// commonly happens.
-
 	metrics.IncCounter(MetricCmdAppendL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Append(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistAppendL2, uint64(dur))
 
 	if err != nil {
 		// Appending in L2 did not succeed. Don't try in L1 since this means L2
@@ -203,7 +230,11 @@ func (l *L1L2BatchOrca) Append(req common.SetRequest) error {
 	// there's an error, we need to fail because we're not in an unknown state
 	// where L1 possibly doesn't have the append when L2 does. We don't recover
 	// from this but instead fail the request and let the client retry.
+	metrics.IncCounter(MetricCmdAppendL1)
+	start = time.Now().UnixNano()
 	err = l.l1.Append(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistAppendL1, uint64(dur))
 
 	if err != nil {
 		// Not stored in L1 is still fine. There's a possibility that a
@@ -230,7 +261,10 @@ func (l *L1L2BatchOrca) Prepend(req common.SetRequest) error {
 	//log.Println("prepend", string(req.Key))
 
 	metrics.IncCounter(MetricCmdPrependL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Prepend(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistPrependL2, uint64(dur))
 
 	if err != nil {
 		// Prepending in L2 did not succeed. Don't try in L1 since this means L2
@@ -251,7 +285,11 @@ func (l *L1L2BatchOrca) Prepend(req common.SetRequest) error {
 	// there's an error, we need to fail because we're not in an unknown state
 	// where L1 possibly doesn't have the Prepend when L2 does. We don't recover
 	// from this but instead fail the request and let the client retry.
+	metrics.IncCounter(MetricCmdPrependL1)
+	start = time.Now().UnixNano()
 	err = l.l1.Prepend(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistPrependL1, uint64(dur))
 
 	if err != nil {
 		// Not stored in L1 is still fine. There's a possibility that a
@@ -279,7 +317,10 @@ func (l *L1L2BatchOrca) Delete(req common.DeleteRequest) error {
 
 	// Try L2 first
 	metrics.IncCounter(MetricCmdDeleteL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Delete(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistDeleteL2, uint64(dur))
 
 	if err != nil {
 		// On a delete miss in L2 don't bother deleting in L1. There might be no
@@ -309,7 +350,12 @@ func (l *L1L2BatchOrca) Delete(req common.DeleteRequest) error {
 	// L2, set in L1, then deleted in L2. By deleting from L2 first, if L1 goes
 	// missing then no other request can undo part of this request.
 	metrics.IncCounter(MetricCmdDeleteL1)
-	if err := l.l1.Delete(req); err != nil {
+	start = time.Now().UnixNano()
+	err = l.l1.Delete(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistDeleteL1, uint64(dur))
+
+	if err != nil {
 		// Delete misses in L1 are fine. If we get here, that means the delete
 		// in L2 hit. This isn't a miss per se since the overall effect is a
 		// delete. Concurrent deletes might interleave to produce this, or the
@@ -336,7 +382,10 @@ func (l *L1L2BatchOrca) Touch(req common.TouchRequest) error {
 
 	// Try L2 first
 	metrics.IncCounter(MetricCmdTouchL2)
+	start := time.Now().UnixNano()
 	err := l.l2.Touch(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistTouchL2, uint64(dur))
 
 	if err != nil {
 		// On a touch miss in L2 don't bother touch in L1. The data should be
@@ -366,7 +415,12 @@ func (l *L1L2BatchOrca) Touch(req common.TouchRequest) error {
 	// in L1 might live longer. Touching keeps hot data hot, while delete is
 	// more disruptive.
 	metrics.IncCounter(MetricCmdTouchTouchL1)
-	if err := l.l1.Touch(req); err != nil {
+	start = time.Now().UnixNano()
+	err = l.l1.Touch(req)
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistTouchL1, uint64(dur))
+
+	if err != nil {
 		if err == common.ErrKeyNotFound {
 			// For a touch miss in L1, there's no problem.
 			metrics.IncCounter(MetricCmdTouchTouchMissesL1)
@@ -395,6 +449,7 @@ func (l *L1L2BatchOrca) Get(req common.GetRequest) error {
 
 	metrics.IncCounter(MetricCmdGetL1)
 	metrics.IncCounterBy(MetricCmdGetKeysL1, uint64(len(req.Keys)))
+	start := time.Now().UnixNano()
 	resChan, errChan := l.l1.Get(req)
 
 	var err error
@@ -441,6 +496,10 @@ func (l *L1L2BatchOrca) Get(req common.GetRequest) error {
 		}
 	}
 
+	// record metrics before going to L2
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistGetL1, uint64(dur))
+
 	// leave early on all hits
 	if len(l2keys) == 0 {
 		if err != nil {
@@ -460,6 +519,7 @@ func (l *L1L2BatchOrca) Get(req common.GetRequest) error {
 
 	metrics.IncCounter(MetricCmdGetL2)
 	metrics.IncCounterBy(MetricCmdGetKeysL2, uint64(len(l2keys)))
+	start = time.Now().UnixNano()
 	resChan, errChan = l.l2.Get(req)
 	for {
 		select {
@@ -510,6 +570,9 @@ func (l *L1L2BatchOrca) Get(req common.GetRequest) error {
 		}
 	}
 
+	dur = time.Now().UnixNano() - start
+	metrics.ObserveHist(HistGetL2, uint64(dur))
+
 	if err == nil {
 		return l.res.GetEnd(req.NoopOpaque, req.NoopEnd)
 	}
@@ -528,7 +591,10 @@ func (l *L1L2BatchOrca) Gat(req common.GATRequest) error {
 
 	// Perform L2 for correctness, invalidate in L1 later
 	metrics.IncCounter(MetricCmdGatL2)
+	start := time.Now().UnixNano()
 	res, err := l.l2.GAT(req)
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistGatL2, uint64(dur))
 
 	// Errors here are genrally fatal to the connection, as something has gone
 	// seriously wrong. Bail out early.
@@ -553,8 +619,8 @@ func (l *L1L2BatchOrca) Gat(req common.GATRequest) error {
 	} else {
 		metrics.IncCounter(MetricCmdGatHitsL2)
 
-		// Success finding and touching the data in L2, but still need to make
-		// sure that the data is *not* in L1 by invalidating it.
+		// Success finding and touching the data in L2, but still need to touch
+		// in L1
 		touchreq := common.TouchRequest{
 			Key:    req.Key,
 			Opaque: req.Opaque,
@@ -562,7 +628,12 @@ func (l *L1L2BatchOrca) Gat(req common.GATRequest) error {
 
 		// Try touching in L1 to touch hot data. See touch impl for reasoning.
 		metrics.IncCounter(MetricCmdGatTouchL1)
-		if err := l.l1.Touch(touchreq); err != nil {
+		start = time.Now().UnixNano()
+		err = l.l1.Touch(touchreq)
+		dur = time.Now().UnixNano() - start
+		metrics.ObserveHist(HistTouchL1, uint64(dur))
+
+		if err != nil {
 			if err == common.ErrKeyNotFound {
 				// For a touch miss in L1, there's no problem.
 				metrics.IncCounter(MetricCmdGatTouchMissesL1)

--- a/orcas/l1only.go
+++ b/orcas/l1only.go
@@ -15,6 +15,8 @@
 package orcas
 
 import (
+	"time"
+
 	"github.com/netflix/rend/common"
 	"github.com/netflix/rend/handlers"
 	"github.com/netflix/rend/metrics"
@@ -36,7 +38,12 @@ func (l *L1OnlyOrca) Set(req common.SetRequest) error {
 	//log.Println("set", string(req.Key))
 
 	metrics.IncCounter(MetricCmdSetL1)
+	start := time.Now().UnixNano()
+
 	err := l.l1.Set(req)
+
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistSetL1, uint64(dur))
 
 	if err == nil {
 		metrics.IncCounter(MetricCmdSetSuccessL1)
@@ -56,7 +63,12 @@ func (l *L1OnlyOrca) Add(req common.SetRequest) error {
 	//log.Println("add", string(req.Key))
 
 	metrics.IncCounter(MetricCmdAddL1)
+	start := time.Now().UnixNano()
+
 	err := l.l1.Add(req)
+
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistAddL1, uint64(dur))
 
 	if err == nil {
 		metrics.IncCounter(MetricCmdAddStoredL1)
@@ -79,7 +91,12 @@ func (l *L1OnlyOrca) Replace(req common.SetRequest) error {
 	//log.Println("replace", string(req.Key))
 
 	metrics.IncCounter(MetricCmdReplaceL1)
+	start := time.Now().UnixNano()
+
 	err := l.l1.Replace(req)
+
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistReplaceL1, uint64(dur))
 
 	if err == nil {
 		metrics.IncCounter(MetricCmdReplaceStoredL1)
@@ -102,7 +119,12 @@ func (l *L1OnlyOrca) Append(req common.SetRequest) error {
 	//log.Println("append", string(req.Key))
 
 	metrics.IncCounter(MetricCmdAppendL1)
+	start := time.Now().UnixNano()
+
 	err := l.l1.Append(req)
+
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistAppendL1, uint64(dur))
 
 	if err == nil {
 		metrics.IncCounter(MetricCmdAppendStoredL1)
@@ -125,7 +147,12 @@ func (l *L1OnlyOrca) Prepend(req common.SetRequest) error {
 	//log.Println("prepend", string(req.Key))
 
 	metrics.IncCounter(MetricCmdPrependL1)
+	start := time.Now().UnixNano()
+
 	err := l.l1.Prepend(req)
+
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistPrependL1, uint64(dur))
 
 	if err == nil {
 		metrics.IncCounter(MetricCmdPrependStoredL1)
@@ -148,7 +175,12 @@ func (l *L1OnlyOrca) Delete(req common.DeleteRequest) error {
 	//log.Println("delete", string(req.Key))
 
 	metrics.IncCounter(MetricCmdDeleteL1)
+	start := time.Now().UnixNano()
+
 	err := l.l1.Delete(req)
+
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistDeleteL1, uint64(dur))
 
 	if err == nil {
 		metrics.IncCounter(MetricCmdDeleteHits)
@@ -171,7 +203,12 @@ func (l *L1OnlyOrca) Touch(req common.TouchRequest) error {
 	//log.Println("touch", string(req.Key))
 
 	metrics.IncCounter(MetricCmdTouchL1)
+	start := time.Now().UnixNano()
+
 	err := l.l1.Touch(req)
+
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistTouchL1, uint64(dur))
 
 	if err == nil {
 		metrics.IncCounter(MetricCmdTouchHitsL1)
@@ -201,6 +238,8 @@ func (l *L1OnlyOrca) Get(req common.GetRequest) error {
 
 	metrics.IncCounter(MetricCmdGetL1)
 	metrics.IncCounterBy(MetricCmdGetKeysL1, uint64(len(req.Keys)))
+	start := time.Now().UnixNano()
+
 	resChan, errChan := l.l1.Get(req)
 
 	var err error
@@ -241,6 +280,9 @@ func (l *L1OnlyOrca) Get(req common.GetRequest) error {
 		}
 	}
 
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistGetL1, uint64(dur))
+
 	if err == nil {
 		l.res.GetEnd(req.NoopOpaque, req.NoopEnd)
 	}
@@ -262,6 +304,8 @@ func (l *L1OnlyOrca) GetE(req common.GetRequest) error {
 
 	metrics.IncCounter(MetricCmdGetEL1)
 	metrics.IncCounterBy(MetricCmdGetEKeysL1, uint64(len(req.Keys)))
+	start := time.Now().UnixNano()
+
 	resChan, errChan := l.l1.GetE(req)
 
 	var err error
@@ -302,6 +346,9 @@ func (l *L1OnlyOrca) GetE(req common.GetRequest) error {
 		}
 	}
 
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistGetEL1, uint64(dur))
+
 	if err == nil {
 		l.res.GetEnd(req.NoopOpaque, req.NoopEnd)
 	}
@@ -313,7 +360,12 @@ func (l *L1OnlyOrca) Gat(req common.GATRequest) error {
 	//log.Println("gat", string(req.Key))
 
 	metrics.IncCounter(MetricCmdGatL1)
+	start := time.Now().UnixNano()
+
 	res, err := l.l1.GAT(req)
+
+	dur := time.Now().UnixNano() - start
+	metrics.ObserveHist(HistGatL1, uint64(dur))
 
 	if err == nil {
 		if res.Miss {

--- a/orcas/types.go
+++ b/orcas/types.go
@@ -208,4 +208,35 @@ var (
 	MetricCmdGatTouchMissesL1 = metrics.AddCounter("cmd_gat_touch_misses_l1")
 	MetricCmdGatTouchErrorsL1 = metrics.AddCounter("cmd_gat_touch_errors_l1")
 	MetricCmdGatTouchHitsL1   = metrics.AddCounter("cmd_gat_touch_hits_l1")
+
+	// Histograms for sub-operations
+	HistSetL1     = metrics.AddHistogram("set_l1", false)
+	HistSetL2     = metrics.AddHistogram("set_l2", false)
+	HistAddL1     = metrics.AddHistogram("add_l1", false)
+	HistAddL2     = metrics.AddHistogram("add_l2", false)
+	HistReplaceL1 = metrics.AddHistogram("replace_l1", false)
+	HistReplaceL2 = metrics.AddHistogram("replace_l2", false)
+	HistAppendL1  = metrics.AddHistogram("append_l1", false)
+	HistAppendL2  = metrics.AddHistogram("append_l2", false)
+	HistPrependL1 = metrics.AddHistogram("prepend_l1", false)
+	HistPrependL2 = metrics.AddHistogram("prepend_l2", false)
+	HistDeleteL1  = metrics.AddHistogram("delete_l1", false)
+	HistDeleteL2  = metrics.AddHistogram("delete_l2", false)
+	HistTouchL1   = metrics.AddHistogram("touch_l1", false)
+	HistTouchL2   = metrics.AddHistogram("touch_l2", false)
+
+	HistGetL1 = metrics.AddHistogram("get_l1", false) // not sampled until configurable
+	HistGetL2 = metrics.AddHistogram("get_l2", false) // not sampled until configurable
+	//HistGetSingleL1 = metrics.AddHistogram("get_single_l1", false) // not sampled until configurable
+	//HistGetSingleL2 = metrics.AddHistogram("get_single_l2", false) // not sampled until configurable
+
+	HistGetEL1 = metrics.AddHistogram("gete_l1", false) // not sampled until configurable
+	HistGetEL2 = metrics.AddHistogram("gete_l2", false) // not sampled until configurable
+	//HistGetESingleL1 = metrics.AddHistogram("gete_single_l1", false) // not sampled until configurable
+	//HistGetESingleL2 = metrics.AddHistogram("gete_single_l2", false) // not sampled until configurable
+
+	HistGatL1 = metrics.AddHistogram("gat_l1", false) // not sampled until configurable
+	HistGatL2 = metrics.AddHistogram("gat_l2", false) // not sampled until configurable
+	//HistGatSingleL1 = metrics.AddHistogram("gat_single_l1", false) // not sampled until configurable
+	//HistGatSingleL2 = metrics.AddHistogram("gat_single_l2", false) // not sampled until configurable
 )


### PR DESCRIPTION
This PR adds histograms to the sub-operations that combine to make up an overall operation. For example, a get operation overall may be comprised of a get in L1, a get in L2, and a set in L1. Right now the only metrics we have are for the overall operations. In order to gain better insight, we will now have timing information on L1 and L2 individual operations.

This does add some additional memory use, but it's only a few megabytes (and in large chunks) so it's not a big deal.

closes #66 

CC @smadappa @vuzilla @senugula @akpratt for review