### PR TITLE
Removing req.Quiet changes in the L1L2Batch orchestrator.

### DIFF
--- a/orcas/l1l2batch.go
+++ b/orcas/l1l2batch.go
@@ -58,7 +58,6 @@ func (l *L1L2BatchOrca) Set(req common.SetRequest) error {
 	metrics.IncCounter(MetricCmdSetSuccessL2)
 
 	// Replace the entry in L1.
-	req.Quiet = false
 	metrics.IncCounter(MetricCmdSetReplaceL1)
 	start = time.Now().UnixNano()
 
@@ -117,7 +116,6 @@ func (l *L1L2BatchOrca) Add(req common.SetRequest) error {
 	metrics.IncCounter(MetricCmdAddStoredL2)
 
 	// Replace the entry in L1.
-	req.Quiet = false
 	metrics.IncCounter(MetricCmdAddReplaceL1)
 	start = time.Now().UnixNano()
 
@@ -176,7 +174,6 @@ func (l *L1L2BatchOrca) Replace(req common.SetRequest) error {
 	metrics.IncCounter(MetricCmdReplaceStoredL2)
 
 	// Replace the entry in L1.
-	req.Quiet = false
 	metrics.IncCounter(MetricCmdReplaceReplaceL1)
 	start = time.Now().UnixNano()
 


### PR DESCRIPTION
Under high load, rend would receive SETQ calls, which do not expect a response. When the client got a response, it assumed a problem and disconnected. This is exactly the worst thing to do under heavy load as it requires clients to reconnect, which takes even longer. This change removes the erroneous erasure of the quiet flag.

Closes #94 

CC @vuzilla @smadappa @senugula @akpratt for review