### PR TITLE
Add .travis.yml config for Travis CI support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+# Default options and settings are described in:
+# https://docs.travis-ci.com/user/languages/go
+language: go
+
+dist: trusty
+sudo: false


### PR DESCRIPTION
The default options for Go projects might be sufficient as per instructions.
This config simply adds the setting to use the most-recent Linux distro
available on Travis CI (Trusty) and disables `sudo` to use the more efficient
container-based infrastructure.

Additional customizations can be added once this config is enabled and it's easy
to test new iterations via the GitHub PR mechanism, which will get Travis to
test each PR automatically.

Note that a repo admin needs to activate this repo on Travis CI by going to this page:
https://travis-ci.org/Netflix/rend