### PR TITLE
fix : client textprot Get always return "END\r\n"

### DIFF
--- a/client/textprot/prot.go
+++ b/client/textprot/prot.go
@@ -137,15 +137,15 @@ func (t TextProt) Get(rw *bufio.ReadWriter, key []byte) ([]byte, error) {
 	rw.Flush()
 
 	// read the header line
-	response, err := rw.ReadString('\n')
+	header, err := rw.ReadString('\n')
 	if err != nil {
 		return nil, err
 	}
 	if VERBOSE {
-		fmt.Println(response)
+		fmt.Println(header)
 	}
 
-	if strings.TrimSpace(response) == "END" {
+	if strings.TrimSpace(header) == "END" {
 		if VERBOSE {
 			fmt.Println("Empty response / cache miss")
 		}
@@ -153,24 +153,25 @@ func (t TextProt) Get(rw *bufio.ReadWriter, key []byte) ([]byte, error) {
 	}
 
 	// then read the value
-	response, err = rw.ReadString('\n')
+	value, err := rw.ReadString('\n')
 	if err != nil {
 		return nil, err
 	}
 	if VERBOSE {
-		fmt.Println(response)
+		fmt.Println(value)
 	}
+	value = strings.TrimSpace(value)
 
 	// then read the END
-	response, err = rw.ReadString('\n')
-	if err != nil {
+	if footer, err := rw.ReadString('\n'); err != nil {
 		return nil, err
+	} else {
+		if VERBOSE {
+			fmt.Println(footer)
+			fmt.Printf("Got key %s\n", key)
+		}
 	}
-	if VERBOSE {
-		fmt.Println(response)
-		fmt.Printf("Got key %s\n", key)
-	}
-	return []byte(response), nil
+	return []byte(value), nil
 }
 
 func (t TextProt) BatchGet(rw *bufio.ReadWriter, keys [][]byte) ([][]byte, error) {


### PR DESCRIPTION
Hi !

I was testing my custom handler then I spotted a weird bug :)

```
> go run setget.go -p 11211 -w 1 -n 1
2017/02/09 10:50:42 Done generating keys
Connected to memcached.
Setting key AAAB to value of length 8101
STORED

Set key AAAB
Getting key AAAB
VALUE AAAB 0 8101

ZJQFS
[...]
LOXFW

END

Got key AAAB

return = [69 78 68 13 10] --> "END\CR\LF"

2017/02/09 10:50:42 Data returned from server does not match! 
Data len sent: 8101 
Data len recv: 5
2017/02/09 10:50:42 Total comm time: 3421833
```

This patch should make textprot Get function return what is expected (trimmed value)

Thanks for your work !