### PR TITLE
Change travis import path to match lowercase "netflix"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ sudo: false
 
 go_import_path: github.com/netflix/rend
 install: true
+script: go test -v $(go list ./... | grep -v client)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ language: go
 
 dist: trusty
 sudo: false
+
+go_import_path: github.com/netflix/rend

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ dist: trusty
 sudo: false
 
 go_import_path: github.com/netflix/rend
+install: true

--- a/binprot/parser_test.go
+++ b/binprot/parser_test.go
@@ -36,7 +36,7 @@ func TestUnknownCommand(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, // CAS
 		0x00, 0x00, 0x00, 0x00, // CAS
 	}))
-	req, reqType, err := binprot.NewBinaryParser(r).Parse()
+	req, reqType, _, err := binprot.NewBinaryParser(r).Parse()
 
 	if req != nil {
 		t.Fatal("Expected request struct to be nil")


### PR DESCRIPTION
The rend project uses all lowercase import paths even though the Netflix GitHub org is "Netflix"

This changes the import path used on the travis build system to match the lowercase paths.