### PR TITLE
Better handling of problematic sets

### DIFF
--- a/metrics/counters.go
+++ b/metrics/counters.go
@@ -16,7 +16,7 @@ package metrics
 
 import "sync/atomic"
 
-const maxNumCounters = 1024
+const maxNumCounters = 10240
 
 var (
 	cnames       = make([]string, maxNumCounters)

--- a/orcas/l1l2_test.go
+++ b/orcas/l1l2_test.go
@@ -1,0 +1,243 @@
+// Copyright 2017 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orcas_test
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/netflix/rend/common"
+	"github.com/netflix/rend/orcas"
+	"github.com/netflix/rend/protocol/textprot"
+)
+
+func TestL1L2Orca(t *testing.T) {
+	t.Run("Set", func(t *testing.T) {
+		t.Run("L2SetSuccess", func(t *testing.T) {
+			t.Run("L1SetError", func(t *testing.T) {
+				t.Run("L1DeleteHit", func(t *testing.T) {
+					h1 := &testHandler{
+						errors: []error{common.ErrNoMem, nil},
+					}
+					h2 := &testHandler{
+						errors: []error{nil},
+					}
+					output := &bytes.Buffer{}
+
+					l1l2 := orcas.L1L2(h1, h2, textprot.NewTextResponder(bufio.NewWriter(output)))
+
+					err := l1l2.Set(common.SetRequest{})
+					if err != nil {
+						t.Fatalf("Error should be nil, got %v", err)
+					}
+
+					out := string(output.Bytes())
+
+					t.Logf(out)
+
+					if out != "STORED\r\n" {
+						t.Fatalf("Expected response 'STORED\\r\\n' but got '%v'", out)
+					}
+
+					h1.verifyEmpty(t)
+					h2.verifyEmpty(t)
+				})
+				t.Run("L1DeleteMiss", func(t *testing.T) {
+					h1 := &testHandler{
+						errors: []error{common.ErrNoMem, common.ErrKeyNotFound},
+					}
+					h2 := &testHandler{
+						errors: []error{nil},
+					}
+					output := &bytes.Buffer{}
+
+					l1l2 := orcas.L1L2(h1, h2, textprot.NewTextResponder(bufio.NewWriter(output)))
+
+					err := l1l2.Set(common.SetRequest{})
+					if err != nil {
+						t.Fatalf("Error should be nil, got %v", err)
+					}
+
+					out := string(output.Bytes())
+
+					t.Logf(out)
+
+					if out != "STORED\r\n" {
+						t.Fatalf("Expected response 'STORED\\r\\n' but got '%v'", out)
+					}
+
+					h1.verifyEmpty(t)
+					h2.verifyEmpty(t)
+				})
+				t.Run("L1DeleteMiss", func(t *testing.T) {
+					h1 := &testHandler{
+						errors: []error{common.ErrNoMem, io.EOF},
+					}
+					h2 := &testHandler{
+						errors: []error{nil},
+					}
+					output := &bytes.Buffer{}
+
+					l1l2 := orcas.L1L2(h1, h2, textprot.NewTextResponder(bufio.NewWriter(output)))
+
+					err := l1l2.Set(common.SetRequest{})
+					if err != nil {
+						t.Fatalf("Error should be nil, got %v", err)
+					}
+
+					out := string(output.Bytes())
+
+					t.Logf(out)
+
+					if out != "STORED\r\n" {
+						t.Fatalf("Expected response 'STORED\\r\\n' but got '%v'", out)
+					}
+
+					h1.verifyEmpty(t)
+					h2.verifyEmpty(t)
+				})
+			})
+		})
+	})
+	t.Run("Get", func(t *testing.T) {
+		t.Run("L1Miss", func(t *testing.T) {
+			t.Run("L2Hit", func(t *testing.T) {
+				t.Run("L1SetFailure", func(t *testing.T) {
+					t.Run("L1DeleteHit", func(t *testing.T) {
+						h1 := &testHandler{
+							errors: []error{common.ErrNoMem, nil},
+							responses: []common.GetResponse{
+								common.GetResponse{
+									Miss: true,
+								},
+							},
+						}
+						h2 := &testHandler{
+							eresponses: []common.GetEResponse{
+								common.GetEResponse{
+									Key:  []byte("key"),
+									Data: []byte("foo"),
+								},
+							},
+						}
+						output := &bytes.Buffer{}
+
+						l1l2 := orcas.L1L2(h1, h2, textprot.NewTextResponder(bufio.NewWriter(output)))
+
+						err := l1l2.Get(common.GetRequest{
+							Keys:    [][]byte{[]byte("key")},
+							Opaques: []uint32{0},
+							Quiet:   []bool{false},
+							NoopEnd: false,
+						})
+						if err != nil {
+							t.Fatalf("Error should be nil, got %v", err)
+						}
+
+						out := string(output.Bytes())
+
+						t.Logf(out)
+						gold := "VALUE key 0 3\r\nfoo\r\nEND\r\n"
+
+						if out != gold {
+							t.Fatalf("Expected response '%v' but got '%v'", gold, out)
+						}
+
+						h1.verifyEmpty(t)
+						h2.verifyEmpty(t)
+					})
+					t.Run("L1DeleteMiss", func(t *testing.T) {
+						h1 := &testHandler{
+							errors: []error{common.ErrNoMem, common.ErrKeyNotFound},
+							responses: []common.GetResponse{
+								common.GetResponse{
+									Miss: true,
+								},
+							},
+						}
+						h2 := &testHandler{
+							eresponses: []common.GetEResponse{
+								common.GetEResponse{
+									Key:  []byte("key"),
+									Data: []byte("foo"),
+								},
+							},
+						}
+						output := &bytes.Buffer{}
+
+						l1l2 := orcas.L1L2(h1, h2, textprot.NewTextResponder(bufio.NewWriter(output)))
+
+						err := l1l2.Get(common.GetRequest{})
+						if err != nil {
+							t.Fatalf("Error should be nil, got %v", err)
+						}
+
+						out := string(output.Bytes())
+
+						t.Logf(out)
+						gold := "VALUE key 0 3\r\nfoo\r\nEND\r\n"
+
+						if out != gold {
+							t.Fatalf("Expected response '%v' but got '%v'", gold, out)
+						}
+
+						h1.verifyEmpty(t)
+						h2.verifyEmpty(t)
+					})
+					t.Run("L1DeleteError", func(t *testing.T) {
+						h1 := &testHandler{
+							errors: []error{common.ErrNoMem, io.EOF},
+							responses: []common.GetResponse{
+								common.GetResponse{
+									Miss: true,
+								},
+							},
+						}
+						h2 := &testHandler{
+							eresponses: []common.GetEResponse{
+								common.GetEResponse{
+									Key:  []byte("key"),
+									Data: []byte("foo"),
+								},
+							},
+						}
+						output := &bytes.Buffer{}
+
+						l1l2 := orcas.L1L2(h1, h2, textprot.NewTextResponder(bufio.NewWriter(output)))
+
+						err := l1l2.Get(common.GetRequest{})
+						if err != nil {
+							t.Fatalf("Error should be nil, got %v", err)
+						}
+
+						out := string(output.Bytes())
+
+						t.Logf(out)
+						gold := "VALUE key 0 3\r\nfoo\r\nEND\r\n"
+
+						if out != gold {
+							t.Fatalf("Expected response '%v' but got '%v'", gold, out)
+						}
+
+						h1.verifyEmpty(t)
+						h2.verifyEmpty(t)
+					})
+				})
+			})
+		})
+	})
+}

--- a/orcas/l1l2batch_test.go
+++ b/orcas/l1l2batch_test.go
@@ -1,0 +1,116 @@
+// Copyright 2017 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orcas_test
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"testing"
+
+	"github.com/netflix/rend/common"
+	"github.com/netflix/rend/orcas"
+	"github.com/netflix/rend/protocol/textprot"
+)
+
+func TestL1L2BatchOrca(t *testing.T) {
+	t.Run("Set", func(t *testing.T) {
+		t.Run("L2SetSuccess", func(t *testing.T) {
+			t.Run("L1SetError", func(t *testing.T) {
+				t.Run("L1DeleteHit", func(t *testing.T) {
+					h1 := &testHandler{
+						errors: []error{common.ErrNoMem, nil},
+					}
+					h2 := &testHandler{
+						errors: []error{nil},
+					}
+					output := &bytes.Buffer{}
+
+					l1l2 := orcas.L1L2Batch(h1, h2, textprot.NewTextResponder(bufio.NewWriter(output)))
+
+					err := l1l2.Set(common.SetRequest{})
+					if err != nil {
+						t.Fatalf("Error should be nil, got %v", err)
+					}
+
+					out := string(output.Bytes())
+
+					t.Logf(out)
+
+					if out != "STORED\r\n" {
+						t.Fatalf("Expected response 'STORED\\r\\n' but got '%v'", out)
+					}
+
+					h1.verifyEmpty(t)
+					h2.verifyEmpty(t)
+				})
+				t.Run("L1DeleteMiss", func(t *testing.T) {
+					h1 := &testHandler{
+						errors: []error{common.ErrNoMem, common.ErrKeyNotFound},
+					}
+					h2 := &testHandler{
+						errors: []error{nil},
+					}
+					output := &bytes.Buffer{}
+
+					l1l2 := orcas.L1L2Batch(h1, h2, textprot.NewTextResponder(bufio.NewWriter(output)))
+
+					err := l1l2.Set(common.SetRequest{})
+					if err != nil {
+						t.Fatalf("Error should be nil, got %v", err)
+					}
+
+					out := string(output.Bytes())
+
+					t.Logf(out)
+
+					if out != "STORED\r\n" {
+						t.Fatalf("Expected response 'STORED\\r\\n' but got '%v'", out)
+					}
+
+					h1.verifyEmpty(t)
+					h2.verifyEmpty(t)
+				})
+				t.Run("L1DeleteMiss", func(t *testing.T) {
+					h1 := &testHandler{
+						errors: []error{common.ErrNoMem, io.EOF},
+					}
+					h2 := &testHandler{
+						errors: []error{nil},
+					}
+					output := &bytes.Buffer{}
+
+					l1l2 := orcas.L1L2Batch(h1, h2, textprot.NewTextResponder(bufio.NewWriter(output)))
+
+					err := l1l2.Set(common.SetRequest{})
+					if err != nil {
+						t.Fatalf("Error should be nil, got %v", err)
+					}
+
+					out := string(output.Bytes())
+
+					t.Logf(out)
+
+					if out != "STORED\r\n" {
+						t.Fatalf("Expected response 'STORED\\r\\n' but got '%v'", out)
+					}
+
+					h1.verifyEmpty(t)
+					h2.verifyEmpty(t)
+				})
+			})
+		})
+	})
+}

--- a/orcas/types.go
+++ b/orcas/types.go
@@ -57,10 +57,14 @@ var (
 	MetricCmdGetKeysL1   = metrics.AddCounter("cmd_get_keys_l1", nil)
 	MetricCmdGetKeysL2   = metrics.AddCounter("cmd_get_keys_l2", nil)
 
-	// Batch L1L2 get metrics
 	MetricCmdGetSetL1       = metrics.AddCounter("cmd_get_set_l1", nil)
 	MetricCmdGetSetErrorsL1 = metrics.AddCounter("cmd_get_set_errors_l1", nil)
 	MetricCmdGetSetSucessL1 = metrics.AddCounter("cmd_get_set_success_l1", nil)
+
+	MetricCmdGetSetErrorL1DeleteL1       = metrics.AddCounter("cmd_get_set_l1_error_delete_l1", nil)
+	MetricCmdGetSetErrorL1DeleteHitsL1   = metrics.AddCounter("cmd_get_set_l1_error_delete_hits_l1", nil)
+	MetricCmdGetSetErrorL1DeleteMissesL1 = metrics.AddCounter("cmd_get_set_l1_error_delete_misses_l1", nil)
+	MetricCmdGetSetErrorL1DeleteErrorsL1 = metrics.AddCounter("cmd_get_set_l1_error_delete_errors_l1", nil)
 
 	MetricCmdGetEL1       = metrics.AddCounter("cmd_gete_l1", nil)
 	MetricCmdGetEL2       = metrics.AddCounter("cmd_gete_l2", nil)
@@ -86,11 +90,23 @@ var (
 	MetricCmdSetErrorsL1  = metrics.AddCounter("cmd_set_errors_l1", nil)
 	MetricCmdSetErrorsL2  = metrics.AddCounter("cmd_set_errors_l2", nil)
 
+	// L1L2 delete after failed L1 set metrics
+	MetricCmdSetL1ErrorDeleteL1       = metrics.AddCounter("cmd_set_l1_error_delete_l1", nil)
+	MetricCmdSetL1ErrorDeleteHitsL1   = metrics.AddCounter("cmd_set_l1_error_delete_hits_l1", nil)
+	MetricCmdSetL1ErrorDeleteMissesL1 = metrics.AddCounter("cmd_set_l1_error_delete_misses_l1", nil)
+	MetricCmdSetL1ErrorDeleteErrorsL1 = metrics.AddCounter("cmd_set_l1_error_delete_errors_l1", nil)
+
 	// Batch L1L2 set metrics
 	MetricCmdSetReplaceL1          = metrics.AddCounter("cmd_set_replace_l1", nil)
 	MetricCmdSetReplaceNotStoredL1 = metrics.AddCounter("cmd_set_replace_not_stored_l1", nil)
 	MetricCmdSetReplaceErrorsL1    = metrics.AddCounter("cmd_set_replace_errors_l1", nil)
 	MetricCmdSetReplaceStoredL1    = metrics.AddCounter("cmd_set_replace_stored_l1", nil)
+
+	// Batch L1L2 delete after failed set metrics
+	MetricsCmdSetReplaceL1ErrorDeleteL1       = metrics.AddCounter("cmd_set_replace_l1_error_delete_l1", nil)
+	MetricsCmdSetReplaceL1ErrorDeleteHitsL1   = metrics.AddCounter("cmd_set_replace_l1_error_delete_hits_l1", nil)
+	MetricsCmdSetReplaceL1ErrorDeleteMissesL1 = metrics.AddCounter("cmd_set_replace_l1_error_delete_misses_l1", nil)
+	MetricsCmdSetReplaceL1ErrorDeleteErrorsL1 = metrics.AddCounter("cmd_set_replace_l1_error_delete_errors_l1", nil)
 
 	MetricCmdAddL1          = metrics.AddCounter("cmd_add_l1", nil)
 	MetricCmdAddL2          = metrics.AddCounter("cmd_add_l2", nil)

--- a/orcas/util_test.go
+++ b/orcas/util_test.go
@@ -1,0 +1,135 @@
+// Copyright 2017 Netflix, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package orcas_test
+
+import (
+	"testing"
+
+	"github.com/netflix/rend/common"
+)
+
+type testHandler struct {
+	errors     []error
+	responses  []common.GetResponse
+	eresponses []common.GetEResponse
+}
+
+func (h *testHandler) verifyEmpty(t *testing.T) {
+	if len(h.errors) > 0 {
+		t.Fatalf("Expected errors to be empty. Left over: %#v", h.errors)
+	}
+	if len(h.responses) > 0 {
+		t.Fatalf("Expected errors to be empty. Left over: %#v", h.responses)
+	}
+	if len(h.eresponses) > 0 {
+		t.Fatalf("Expected errors to be empty. Left over: %#v", h.eresponses)
+	}
+}
+
+func (h *testHandler) Set(cmd common.SetRequest) error {
+	ret := h.errors[0]
+	h.errors = h.errors[1:]
+	return ret
+}
+func (h *testHandler) Add(cmd common.SetRequest) error {
+	ret := h.errors[0]
+	h.errors = h.errors[1:]
+	return ret
+}
+func (h *testHandler) Replace(cmd common.SetRequest) error {
+	ret := h.errors[0]
+	h.errors = h.errors[1:]
+	return ret
+}
+func (h *testHandler) Append(cmd common.SetRequest) error {
+	ret := h.errors[0]
+	h.errors = h.errors[1:]
+	return ret
+}
+func (h *testHandler) Prepend(cmd common.SetRequest) error {
+	ret := h.errors[0]
+	h.errors = h.errors[1:]
+	return ret
+}
+func (h *testHandler) Get(cmd common.GetRequest) (<-chan common.GetResponse, <-chan error) {
+	if len(h.responses) > 0 {
+		res := h.responses[0]
+		h.responses = h.responses[1:]
+		reschan := make(chan common.GetResponse, 1)
+		reschan <- res
+		close(reschan)
+
+		errchan := make(chan error)
+		close(errchan)
+
+		return reschan, errchan
+	}
+
+	reschan := make(chan common.GetResponse)
+	close(reschan)
+
+	err := h.errors[0]
+	h.errors = h.errors[1:]
+	errchan := make(chan error, 1)
+	errchan <- err
+	close(errchan)
+
+	return reschan, errchan
+}
+func (h *testHandler) GetE(cmd common.GetRequest) (<-chan common.GetEResponse, <-chan error) {
+	if len(h.eresponses) > 0 {
+		res := h.eresponses[0]
+		h.eresponses = h.eresponses[1:]
+		reschan := make(chan common.GetEResponse, 1)
+		reschan <- res
+		close(reschan)
+
+		errchan := make(chan error)
+		close(errchan)
+
+		return reschan, errchan
+	}
+
+	reschan := make(chan common.GetEResponse)
+	close(reschan)
+
+	err := h.errors[0]
+	h.errors = h.errors[1:]
+	errchan := make(chan error, 1)
+	errchan <- err
+	close(errchan)
+
+	return reschan, errchan
+}
+func (h *testHandler) GAT(cmd common.GATRequest) (common.GetResponse, error) {
+	ret := h.errors[0]
+	h.errors = h.errors[1:]
+	return common.GetResponse{}, ret
+}
+func (h *testHandler) Delete(cmd common.DeleteRequest) error {
+	ret := h.errors[0]
+	h.errors = h.errors[1:]
+	return ret
+}
+func (h *testHandler) Touch(cmd common.TouchRequest) error {
+	ret := h.errors[0]
+	h.errors = h.errors[1:]
+	return ret
+}
+func (h *testHandler) Close() error {
+	ret := h.errors[0]
+	h.errors = h.errors[1:]
+	return ret
+}


### PR DESCRIPTION
Previously, things like an out of memory error may mean that there is an inconsistent state in L1 after a set operation. On any kind of error during a set operation a delete will be sent to L1 afterwards and the operation will succeed even though L1 had an error.

This PR is the beginning of fixing #102 