### PR TITLE
Batching connection fix

### DIFF
--- a/handlers/memcached/batched/conn.go
+++ b/handlers/memcached/batched/conn.go
@@ -148,6 +148,7 @@ func (c conn) reconnect() {
 				// i == connectTries - 1
 				// This means we have failed to open a connection...
 				// panic?
+				panic("Reconnect took too long")
 			}
 		}
 

--- a/handlers/memcached/batched/handler.go
+++ b/handlers/memcached/batched/handler.go
@@ -104,13 +104,13 @@ func (h Handler) Close() error {
 }
 
 const (
-	maxRetryMetrics            = 20
+	maxRetryMetrics            = 10
 	requestRetryMetricName     = "batch_request_retry"
 	requestRetryAttemptTagName = "attempt"
 )
 
 var (
-	requestRetryMetrics    []uint32
+	requestRetryMetrics    = make([]uint32, maxRetryMetrics)
 	metricRequestRetryHigh = metrics.AddCounter(
 		requestRetryMetricName,
 		metrics.Tags{requestRetryAttemptTagName: "high"},

--- a/handlers/memcached/batched/handler.go
+++ b/handlers/memcached/batched/handler.go
@@ -101,14 +101,23 @@ func (h Handler) Close() error {
 	return nil
 }
 
-const requestTries = 3
-
 // TODO: retry metrics
 
-func (h Handler) doSimpleRequest(cmd common.Request, reqType common.RequestType) error {
+func (h Handler) doRequest(cmd common.Request, reqType common.RequestType) (common.GetEResponse, error) {
 	var res response
 
-	for i := 0; i < 3; i++ {
+	// If we don't try more times than the number of connections, one request may
+	// go down the line and cause all the different connections to realize that they
+	// are no longer connected. This means the one request sees many more reconnects
+	// and might fail very quickly. We can give it a chance to actually succeed by
+	// guaranteeing that it sees a connection that has reconnected from this single
+	// reconnect phase. This does not guarantee exactly that the request will get sent
+	// to the server, only that it does not get rejected from only a single reconnect
+	// event.
+	conns := h.relay.conns.Load().([]*conn)
+	maxTries := len(conns) * 2
+
+	for i := 0; i < maxTries; i++ {
 		reschan := make(chan response)
 
 		h.relay.submit(h.rand, request{
@@ -128,44 +137,58 @@ func (h Handler) doSimpleRequest(cmd common.Request, reqType common.RequestType)
 		}
 
 		// TODO: increment metric for retrying
+		/*if i < maxTries-1 {
+			<-time.After(time.Millisecond)
+		}*/
 	}
 
-	return res.err
+	if res.err == errRetryRequestBecauseOfConnectionFailure {
+		return common.GetEResponse{}, common.ErrInternal
+	}
+
+	return res.gr, res.err
 }
 
 // Set performs a set operation on the backend. It unconditionally sets a key to a value.
 func (h Handler) Set(cmd common.SetRequest) error {
-	return h.doSimpleRequest(cmd, common.RequestSet)
+	_, err := h.doRequest(cmd, common.RequestSet)
+	return err
 }
 
 // Add performs an add operation on the backend. It only sets the value if it does not already exist.
 func (h Handler) Add(cmd common.SetRequest) error {
-	return h.doSimpleRequest(cmd, common.RequestAdd)
+	_, err := h.doRequest(cmd, common.RequestAdd)
+	return err
 }
 
 // Replace performs a replace operation on the backend. It only sets the value if it already exists.
 func (h Handler) Replace(cmd common.SetRequest) error {
-	return h.doSimpleRequest(cmd, common.RequestReplace)
+	_, err := h.doRequest(cmd, common.RequestReplace)
+	return err
 }
 
 // Append performs an append operation on the backend. It will append the data to the value only if it already exists.
 func (h Handler) Append(cmd common.SetRequest) error {
-	return h.doSimpleRequest(cmd, common.RequestAppend)
+	_, err := h.doRequest(cmd, common.RequestAppend)
+	return err
 }
 
 // Prepend performs a prepend operation on the backend. It will prepend the data to the value only if it already exists.
 func (h Handler) Prepend(cmd common.SetRequest) error {
-	return h.doSimpleRequest(cmd, common.RequestPrepend)
+	_, err := h.doRequest(cmd, common.RequestPrepend)
+	return err
 }
 
 // Delete performs a delete operation on the backend. It will unconditionally remove the value.
 func (h Handler) Delete(cmd common.DeleteRequest) error {
-	return h.doSimpleRequest(cmd, common.RequestDelete)
+	_, err := h.doRequest(cmd, common.RequestDelete)
+	return err
 }
 
 // Touch performs a touch operation on the backend. It will overwrite the expiration time with a new one.
 func (h Handler) Touch(cmd common.TouchRequest) error {
-	return h.doSimpleRequest(cmd, common.RequestTouch)
+	_, err := h.doRequest(cmd, common.RequestTouch)
+	return err
 }
 
 func getEResponseToGetResponse(res common.GetEResponse) common.GetResponse {
@@ -182,17 +205,69 @@ func getEResponseToGetResponse(res common.GetEResponse) common.GetResponse {
 // GAT performs a get-and-touch on the backend for the given key. It will retrieve the value while updating the TTL to
 // the one supplied.
 func (h Handler) GAT(cmd common.GATRequest) (common.GetResponse, error) {
-	reschan := make(chan response)
-
-	h.relay.submit(h.rand, request{
-		req:     cmd,
-		reqtype: common.RequestGat,
-		reschan: reschan,
-	})
-
-	res := <-reschan
-	return getEResponseToGetResponse(res.gr), res.err
+	gr, err := h.doRequest(cmd, common.RequestGat)
+	return getEResponseToGetResponse(gr), err
 }
+
+type keyAttrs struct {
+	key    string
+	opaque uint32
+	quiet  bool
+}
+
+type trackermap map[keyAttrs]int
+
+// There may be more than one request with the same key and a different opaque
+// We may also get "malicious" input where multiple requests have the same
+// key and opaque. If the quiet value is the same
+func getRequestToTrackerMap(cmd common.GetRequest) trackermap {
+	tm := make(trackermap)
+
+	for i := range cmd.Keys {
+		key := keyAttrs{
+			key:    string(cmd.Keys[i]),
+			opaque: cmd.Opaques[i],
+			quiet:  cmd.Quiet[i],
+		}
+
+		// we get the 0 value when the map doesn't contain the data so this
+		// i correct even for values that don't yet exist
+		count := tm[key]
+		tm[key] = count + 1
+	}
+
+	return tm
+}
+
+func trackerMapToGetRequest(tm trackermap) common.GetRequest {
+	ret := common.GetRequest{}
+	var end keyAttrs
+
+	for key, count := range tm {
+		// the one that is *not* quiet must go at the end
+		if !key.quiet {
+			end = key
+			continue
+		}
+
+		for i := 0; i < count; i++ {
+			ret.Keys = append(ret.Keys, []byte(key.key))
+			ret.Opaques = append(ret.Opaques, key.opaque)
+			ret.Quiet = append(ret.Quiet, key.quiet)
+		}
+	}
+
+	var zeroKeyAttrs keyAttrs
+	if end != zeroKeyAttrs {
+		ret.Keys = append(ret.Keys, []byte(end.key))
+		ret.Opaques = append(ret.Opaques, end.opaque)
+		ret.Quiet = append(ret.Quiet, end.quiet)
+	}
+
+	return ret
+}
+
+const maxGetBatchRetries = 10
 
 // Get performs a get operation on the backend. It retrieves the whole of the batch of keys given as a group and returns
 // them one at a time over the request channel.
@@ -207,29 +282,69 @@ func realHandleGet(h Handler, cmd common.GetRequest, dataOut chan common.GetResp
 	defer close(errorOut)
 	defer close(dataOut)
 
-	reschan := make(chan response)
+	tm := getRequestToTrackerMap(cmd)
+	conns := h.relay.conns.Load().([]*conn)
+	maxTries := len(conns) * 2
 
-	h.relay.submit(h.rand, request{
-		req:     cmd,
-		reqtype: common.RequestGet,
-		reschan: reschan,
-	})
+	for i := 0; i < maxTries; i++ {
+		reschan := make(chan response)
 
-	var errored bool
-
-	for res := range reschan {
-		if res.err != nil {
-			errorOut <- res.err
-			errored = true
+		if i > 0 {
+			// on a retry we need to generate the subset of keys that were not server the first time around
+			// to be resubmitted
+			cmd = trackerMapToGetRequest(tm)
 		}
 
-		// after an error, drop all the rest of the responses. The contract of the handler interface
-		// says that an error will be the last thing to come through.
-		if errored {
-			continue
+		h.relay.submit(h.rand, request{
+			req:     cmd,
+			reqtype: common.RequestGet,
+			reschan: reschan,
+		})
+
+		errored := false
+
+		for res := range reschan {
+			// after an error, drop all the rest of the responses. The contract of the handler interface
+			// says that an error will be the last thing to come through; this is just for safety so the
+			// connection is guaranteed to not get blocked.
+			if errored {
+				continue
+			}
+
+			if res.err != nil {
+				// On the last go-round we can return the error back to the caller
+				// because we will no longer be trying to succeed
+				if i == maxTries-1 {
+					if res.err == errRetryRequestBecauseOfConnectionFailure {
+						errorOut <- common.ErrInternal
+					} else {
+						errorOut <- res.err
+					}
+				}
+				errored = true
+				continue
+			}
+
+			key := keyAttrs{
+				key:    string(res.gr.Key),
+				opaque: res.gr.Opaque,
+				quiet:  res.gr.Quiet,
+			}
+
+			if count, ok := tm[key]; ok {
+				if count == 1 {
+					delete(tm, key)
+				} else {
+					tm[key] = count - 1
+				}
+			}
+
+			dataOut <- getEResponseToGetResponse(res.gr)
 		}
 
-		dataOut <- getEResponseToGetResponse(res.gr)
+		if len(tm) == 0 {
+			break
+		}
 	}
 }
 
@@ -246,28 +361,68 @@ func realHandleGetE(h Handler, cmd common.GetRequest, dataOut chan common.GetERe
 	defer close(errorOut)
 	defer close(dataOut)
 
-	reschan := make(chan response)
+	tm := getRequestToTrackerMap(cmd)
+	conns := h.relay.conns.Load().([]*conn)
+	maxTries := len(conns) * 2
 
-	h.relay.submit(h.rand, request{
-		req:     cmd,
-		reqtype: common.RequestGet,
-		reschan: reschan,
-	})
+	for i := 0; i < maxTries; i++ {
+		reschan := make(chan response)
 
-	var errored bool
-
-	for res := range reschan {
-		if res.err != nil {
-			errorOut <- res.err
-			errored = true
+		if i > 0 {
+			// on a retry we need to generate the subset of keys that were not server the first time around
+			// to be resubmitted
+			cmd = trackerMapToGetRequest(tm)
 		}
 
-		// after an error, drop all the rest of the responses. The contract of the handler interface
-		// says that an error will be the last thing to come through.
-		if errored {
-			continue
+		h.relay.submit(h.rand, request{
+			req:     cmd,
+			reqtype: common.RequestGet,
+			reschan: reschan,
+		})
+
+		errored := false
+
+		for res := range reschan {
+			// after an error, drop all the rest of the responses. The contract of the handler interface
+			// says that an error will be the last thing to come through; this is just for safety so the
+			// connection is guaranteed to not get blocked.
+			if errored {
+				continue
+			}
+
+			if res.err != nil {
+				// On the last go-round we can return the error back to the caller
+				// because we will no longer be trying to succeed
+				if i == maxTries-1 {
+					if res.err == errRetryRequestBecauseOfConnectionFailure {
+						errorOut <- common.ErrInternal
+					} else {
+						errorOut <- res.err
+					}
+				}
+				errored = true
+				continue
+			}
+
+			key := keyAttrs{
+				key:    string(res.gr.Key),
+				opaque: res.gr.Opaque,
+				quiet:  res.gr.Quiet,
+			}
+
+			if count, ok := tm[key]; ok {
+				if count == 1 {
+					delete(tm, key)
+				} else {
+					tm[key] = count - 1
+				}
+			}
+
+			dataOut <- res.gr
 		}
 
-		dataOut <- res.gr
+		if len(tm) == 0 {
+			break
+		}
 	}
 }

--- a/handlers/memcached/batched/types.go
+++ b/handlers/memcached/batched/types.go
@@ -15,11 +15,15 @@
 package batched
 
 import (
-	"encoding/binary"
-
 	crand "crypto/rand"
+	"encoding/binary"
+	"errors"
 
 	"github.com/netflix/rend/common"
+)
+
+var (
+	errRetryRequestBecauseOfConnectionFailure = errors.New("")
 )
 
 type request struct {

--- a/handlers/memcached/batched/types.go
+++ b/handlers/memcached/batched/types.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	errRetryRequestBecauseOfConnectionFailure = errors.New("")
+	errRetryRequestBecauseOfConnectionFailure = errors.New("RETRY_CONN_FAILURE")
 )
 
 type request struct {


### PR DESCRIPTION
This change adds error handling to the batching connection handler to recover when memcached crashes or is killed. This was a somewhat large change as most things needed to gain some extra retry logic.