### PR TITLE
Refactor listener in server to allow for more complex listeners

### DIFF
--- a/memproxy.go
+++ b/memproxy.go
@@ -165,18 +165,12 @@ func init() {
 
 // And away we go
 func main() {
-	var l server.ListenArgs
+	var l server.ListenConst
 
 	if useDomainSocket {
-		l = server.ListenArgs{
-			Type: server.ListenUnix,
-			Path: sockPath,
-		}
+		l = server.UnixListener(sockPath)
 	} else {
-		l = server.ListenArgs{
-			Type: server.ListenTCP,
-			Port: port,
-		}
+		l = server.TCPListener(port)
 	}
 
 	protocols := []protocol.Components{binprot.Components, textprot.Components}
@@ -221,11 +215,7 @@ func main() {
 
 	if l2enabled {
 		// If L2 is enabled, start the batch L1 / L2 orchestrator
-		l = server.ListenArgs{
-			Type: server.ListenTCP,
-			Port: batchPort,
-		}
-
+		l = server.TCPListener(batchPort)
 		o := orcas.L1L2Batch
 
 		if locked {

--- a/server/types.go
+++ b/server/types.go
@@ -16,32 +16,30 @@ package server
 
 import (
 	"io"
+	"net"
 
 	"github.com/netflix/rend/metrics"
 	"github.com/netflix/rend/orcas"
 	"github.com/netflix/rend/protocol"
 )
 
+// ServerConst is a constructor function for servers. Each server implementation should have a
+// corresponding ServerConst to create it.
 type ServerConst func(conns []io.Closer, rp protocol.RequestParser, o orcas.Orca) Server
 
+// Server is the interface that ServerConst returns.
 type Server interface {
+	// Loop is intended to be an infinite loop serving a single connection which will only return when
+	// the connection is done being serviced. The server implementations should be able to runn a single
+	// connection based on the parameters of the ServerConst that created it.
 	Loop()
 }
 
-type ListenType int
+type ListenConst func() (Listener, error)
 
-const (
-	ListenTCP ListenType = iota
-	ListenUnix
-)
-
-type ListenArgs struct {
-	// The type of the connection. "tcp" or "unix" only.
-	Type ListenType
-	// TCP port to listen on, if applicable
-	Port int
-	// Unix domain socket path to listen on, if applicable
-	Path string
+type Listener interface {
+	Accept() (net.Conn, error)
+	ModifyConnSettings(net.Conn) error
 }
 
 var (


### PR DESCRIPTION
There is an internal need for Netflix to allow a listener that has a more complex setup, e.g. internal authentication mechanisms. This refactor allows a user of the libraries to replace the socket bind with whatever mechanism they deem fit. 