### PR TITLE
Updating interface for server.Listener to support wrapped connections

### DIFF
--- a/server/types.go
+++ b/server/types.go
@@ -35,11 +35,13 @@ type Server interface {
 	Loop()
 }
 
+// ListenConst is a constructor function for listener implementations
 type ListenConst func() (Listener, error)
 
+// Listener is a type to accept and configure new connections
 type Listener interface {
 	Accept() (net.Conn, error)
-	ModifyConnSettings(net.Conn) error
+	Configure(net.Conn) (net.Conn, error)
 }
 
 var (


### PR DESCRIPTION
I figured out that some types of connection configurations require returning a wrapped connection, so this interface change adds a return value for the connection along with the error. I also decided (based on previous feedback) that the name ModifyConnSettings was a little verbose and too specific, so that's been changed to Configure. 