### PR TITLE
Add if statement to remote.Close() call

### DIFF
--- a/server/listen.go
+++ b/server/listen.go
@@ -122,7 +122,9 @@ func ListenAndServe(l ListenConst, ps []protocol.Components, s ServerConst, o or
 		remote, err := listener.Accept()
 		if err != nil {
 			log.Println("Error accepting connection from remote:", err.Error())
-			remote.Close()
+			if remote != nil {
+				remote.Close()
+			}
 			continue
 		}
 		metrics.IncCounter(MetricConnectionsEstablishedExt)


### PR DESCRIPTION
After an error in `listener.Accept()` `remote` object can be nil.https://github.com/Netflix/rend/blob/d3db570668d3ecd97cbdf0988c92145a9040e235/server/listen.go#L122 
Calling `remote.Close()` in this line causes a panic.https://github.com/Netflix/rend/blob/d3db570668d3ecd97cbdf0988c92145a9040e235/server/listen.go#L125 

We noticed this behaviour because this error `Error accepting connection from remote: accept tcp [::]:11211: accept4: too many open files` causes our implementation to panic.

Since the wanted behavior is to continue the `listener.Accept()` loop in case of error, we should wrap this particular `remote.Close()` call with an `if remote != nil` statement

Fixes https://github.com/Netflix/rend/issues/129