### PR TITLE
 #135 timer.Now: relocation target runtime.__vdso_clock_gettime_sym n…

### DIFF
--- a/timer/timer_linux_amd64.s
+++ b/timer/timer_linux_amd64.s
@@ -16,7 +16,7 @@
 // Copyright (c) 2009 The Go Authors. All rights reserved.
 // See the NOTICE file for more details.
 TEXT ·Now(SB), 7, $16
-	MOVQ runtime·__vdso_clock_gettime_sym(SB), AX
+	MOVQ runtime·vdsoClockgettimeSym(SB), AX
 	MOVL $1, DI                                   // CLOCK_MONOTONIC
 	LEAQ 0(SP), SI
 	CALL AX


### PR DESCRIPTION
Rend does not build anymore with recent version of go due to:
timer.Now: relocation target runtime.__vdso_clock_gettime_sym not defined

This PR fix this issues